### PR TITLE
MCC-1059946 Changes to add mauth version 2 header support in clojure-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
         - stage: build
           name: "Build & Test"
           script:
-            - lein cljfmt check
             - lein test
         - stage: test
           install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,46 @@
 language: clojure
 dist: trusty
 
-install:
-  - lein deps
+sudo: required
 
-script:
-  - lein test
+addons:
+      apt:
+        packages:
+          - gzip
+
+
+jdk: openjdk11
+
+stages:
+      - name: test
+        if: branch = develop
+      - name: publish
+        if: tag IS present
+
+cache: bundler
+
+jobs:
+      include:
+        - stage: build
+          name: "Build & Test"
+          script:
+            - lein cljfmt check
+            - lein test
+        - stage: test
+          install:
+            - lein deps
+            - lein pom
+          script:
+            - lein test
+        - stage: publish
+          install:
+            - lein deps
+            - lein pom
+          script: lein test
+          deploy:
+            provider: script
+            script: lein deploy
+            skip_cleanup: true
+            on:
+              tags: true
+              all_branches: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Leiningen/Boot Coords:
 
 Here it is folks, a nice, clean MAuth client done in the simplest and most minimal way possible, for your Clojure application.
 
-There are a minimal set of dependencies, it is fast, and can even be used as middleware for securing your applications.
+There are a minimal set of dependencies (Bouncy Castle isn't one of them!), it is fast, and can even be used as middleware for securing your applications.
 
 You do **NOT** need to jump through hoops to use this library. Simple is as simple does.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Leiningen/Boot Coords:
 
-```[clojure-mauth-client "1.0.6"]```
+```[clojure-mauth-client "2.0.1"]```
 
 Here it is folks, a nice, clean MAuth client done in the simplest and most minimal way possible, for your Clojure application.
 
-There are a minimal set of dependencies (Bouncy Castle isn't one of them!), it is fast, and can even be used as middleware for securing your applications.
+There are a minimal set of dependencies, it is fast, and can even be used as middleware for securing your applications.
 
 You do **NOT** need to jump through hoops to use this library. Simple is as simple does.
 
@@ -67,6 +67,14 @@ To do your calls with SNI, pass `:with-sni? true` to your calls.
 
 For example,
 `(mauth/get! "https://www.mdsol.com" "/api/v2/testing.json" :with-sni? true)`
+
+Version 2.0.1 update -
+We have added support for mauth version 2 headers as well now. To get the v2 headers you need to add additional header in your request as
+"mauth-version" with value as "v2" and algorithm also uses query param if any to sign  or to generate these headers, so you will need to add additional header in your request as
+"query-param-string"  and value should be string of sorted and encoded query params e.g abc=abctest&test=testing%20value
+you will get the response version 2 headers as below-
+"mcc-authentication" authentication value
+"mcc-time"           mcc-time
 
 ## Contributing/ Tests
 Tests can be run using `lein test`.

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,6 @@
                  [digest "1.4.8"]
                  [org.clojure/data.codec "0.1.1"]
                  [clojure-interop/java.security "1.0.5"]
-                 ;[clojure-interop/java.net "1.0.5"]
-                 ;[org.bouncycastle/bcpkix-jdk15on "1.53"]
                  [http-kit "2.4.0-alpha2"]
                  [clj-http "3.9.1"]
                  [org.clojure/data.json "0.2.6"]

--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,39 @@
                  [digest "1.4.8"]
                  [org.clojure/data.codec "0.1.1"]
                  [clojure-interop/java.security "1.0.5"]
-                 [clojure-interop/java.net "1.0.5"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.53"]
+                 ;[clojure-interop/java.net "1.0.5"]
+                 ;[org.bouncycastle/bcpkix-jdk15on "1.53"]
                  [http-kit "2.4.0-alpha2"]
                  [clj-http "3.9.1"]
                  [org.clojure/data.json "0.2.6"]
                  [javax.xml.bind/jaxb-api "2.2.11"]]
+
+  :deploy-repositories [["releases" {:url "https://mdsol.jfrog.io/artifactory/common_clj-maven-dev-local/"
+                                     :sign-releases false
+                                     :username :env/artifactory_username
+                                     :password :env/artifactory_password}
+                         "snapshots" {:url "https://mdsol.jfrog.io/artifactory/common_clj-maven-dev-local/"
+                                      :sign-releases false
+                                      :username :env/artifactory_username
+                                      :password :env/artifactory_password}]]
+
+  :release-tasks [["vcs" "assert-committed"]
+                  ["change" "version" "leiningen.release/bump-version" "release"]
+                  ["vcs" "commit"]
+                  ["vcs" "tag" "--no-sign"]
+                  ["vcs" "push"]]
+
+  :aliases {"bump!" ^{:doc "Bump the project version number and push the commits to the original repository."}
+                    ["do"
+                     ["vcs" "assert-committed"]
+                     ["change" "version" "leiningen.release/bump-version"]
+                     ["vcs" "commit"]
+                     ["vcs" "push"]]}
+
+  :target-path "target/%s"
+  :profiles {:uberjar {:aot :all
+                       :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
+
   :jvm-opts ~(concat
                [] ;other opts...
                (if (let [v (-> (System/getProperty "java.version")

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,15 @@
-(defproject clojure-mauth-client "2.0.0"
+(defproject clojure-mauth-client "2.0.1"
   :description "Clojure Mauth Client"
   :url "https://github.com/mdsol/clojure-mauth-client"
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [xsc/pem-reader "0.1.1"]
                  [digest "1.4.8"]
                  [org.clojure/data.codec "0.1.1"]
+                 [clojure-interop/java.security "1.0.5"]
+                 [clojure-interop/java.net "1.0.5"]
+                 [org.bouncycastle/bcpkix-jdk15on "1.53"]
                  [http-kit "2.4.0-alpha2"]
                  [clj-http "3.9.1"]
                  [org.clojure/data.json "0.2.6"]

--- a/project.clj
+++ b/project.clj
@@ -13,11 +13,11 @@
                  [org.clojure/data.json "0.2.6"]
                  [javax.xml.bind/jaxb-api "2.2.11"]]
 
-  :deploy-repositories [["releases" {:url "https://mdsol.jfrog.io/artifactory/common_clj-maven-dev-local/"
+  :deploy-repositories [["releases" {:url "https://mdsol.jfrog.io/artifactory/common_clj-maven-prod-local/"
                                      :sign-releases false
                                      :username :env/artifactory_username
                                      :password :env/artifactory_password}
-                         "snapshots" {:url "https://mdsol.jfrog.io/artifactory/common_clj-maven-dev-local/"
+                         "snapshots" {:url "https://mdsol.jfrog.io/artifactory/common_clj-maven-prod-local/"
                                       :sign-releases false
                                       :username :env/artifactory_username
                                       :password :env/artifactory_password}]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-mauth-client "2.0.1"
+(defproject clojure-mauth-client "2.0.0"
   :description "Clojure Mauth Client"
   :url "https://github.com/mdsol/clojure-mauth-client"
   :license {:name "MIT"

--- a/src/clojure_mauth_client/header.clj
+++ b/src/clojure_mauth_client/header.clj
@@ -66,14 +66,6 @@
 (defn get-hex-encoded-digested-string [msg]
   (msg->sha512 msg))
 
-(defn- make-mcc-auth-string [verb url query-param body app-uuid time]
-  (let [all-params [verb (get-uri url) (get-hex-encoded-digested-string body) app-uuid time query-param]]
-    (clojure.string/join "\n" all-params)))
-
-(defn- make-mcc-auth-string-for-response [status body app-uuid time]
-  (let [all-params [status (get-hex-encoded-digested-string body) app-uuid time]]
-    (clojure.string/join "\n" all-params)))
-
 (defn keydata [reader]
   (->> reader
        (org.bouncycastle.openssl.PEMParser.)

--- a/src/clojure_mauth_client/header.clj
+++ b/src/clojure_mauth_client/header.clj
@@ -1,37 +1,13 @@
 (ns clojure-mauth-client.header
   (:require [pem-reader.core :as pem]
             [clojure.data.codec.base64 :as base64]
-            [clojure.string :refer [blank?]])
+            [clojure-mauth-client.util :as util])
   (:use digest)
   (:import (java.io ByteArrayInputStream)
            (javax.crypto Cipher KeyGenerator SecretKey)))
 
-(defn- epoch-seconds []
-  (long (/ (System/currentTimeMillis) 1000)))
-
-(defn- read-key [key-str]
-  (-> key-str
-      .getBytes
-      ByteArrayInputStream.
-      pem/read)
-  )
-
-(defn- msg->sha512 [msg]
-  (-> msg
-      .getBytes
-      sha-512)
-  )
-
-(defn- get-uri [url]
-  (-> url
-      java.net.URL.
-      .getPath
-      (#(if (blank? %) "/" %))
-      )
-  )
-
 (defn- sign-mauth [message app-uuid private-key]
-  (->> (let [private-key (pem/private-key (read-key private-key))
+  (->> (let [private-key (pem/private-key (util/read-key private-key))
              cipher (doto (Cipher/getInstance "RSA/ECB/PKCS1Padding")
                       (.init Cipher/ENCRYPT_MODE private-key))]
          (.doFinal cipher (.getBytes message)))
@@ -40,7 +16,7 @@
        (str "MWS " app-uuid ":")))
 
 (defn- make-mws-auth-string [verb url body app-uuid time]
-  (->> [verb (get-uri url) body app-uuid time]
+  (->> [verb (util/get-uri url) body app-uuid time]
        (clojure.string/join "\n"))
   )
 
@@ -51,18 +27,17 @@
 
 (defn build-mauth-headers
   ([verb url body app-uuid private-key]
-    (let [x-mws-time (epoch-seconds)
+    (let [x-mws-time (util/epoch-seconds)
           x-mws-authentication (make-mws-auth-string verb url body app-uuid x-mws-time)]
       {"X-MWS-Authentication" (-> x-mws-authentication
-                                  msg->sha512
+                                  util/msg->sha512
                                   (sign-mauth app-uuid private-key))
        "X-MWS-Time"           (str x-mws-time)}))
   ([status body app-uuid private-key]
-   (let [x-mws-time (epoch-seconds)
+   (let [x-mws-time (util/epoch-seconds)
          x-mws-authentication (make-mws-auth-string-for-response status body app-uuid x-mws-time)]
      {"X-MWS-Authentication" (-> x-mws-authentication
-                                 msg->sha512
+                                 util/msg->sha512
                                  (sign-mauth app-uuid private-key))
-      "X-MWS-Time"           (str x-mws-time)}))
-  )
+      "X-MWS-Time"           (str x-mws-time)})))
 

--- a/src/clojure_mauth_client/header.clj
+++ b/src/clojure_mauth_client/header.clj
@@ -1,9 +1,7 @@
 (ns clojure-mauth-client.header
-  (:require [clojure.data.codec.base64 :as base64]
-            [clojure.java.io :as io]
-            [clojure.string :refer [blank?]]
-            [jdk.security.Signature :as signature]
-            [pem-reader.core :as pem])
+  (:require [pem-reader.core :as pem]
+            [clojure.data.codec.base64 :as base64]
+            [clojure.string :refer [blank?]])
   (:use digest)
   (:import (java.io ByteArrayInputStream)
            (javax.crypto Cipher KeyGenerator SecretKey)))
@@ -15,18 +13,22 @@
   (-> key-str
       .getBytes
       ByteArrayInputStream.
-      pem/read))
+      pem/read)
+  )
 
 (defn- msg->sha512 [msg]
   (-> msg
       .getBytes
-      sha-512))
+      sha-512)
+  )
 
 (defn- get-uri [url]
   (-> url
       java.net.URL.
       .getPath
-      (#(if (blank? %) "/" %))))
+      (#(if (blank? %) "/" %))
+      )
+  )
 
 (defn- sign-mauth [message app-uuid private-key]
   (->> (let [private-key (pem/private-key (read-key private-key))
@@ -39,63 +41,28 @@
 
 (defn- make-mws-auth-string [verb url body app-uuid time]
   (->> [verb (get-uri url) body app-uuid time]
-       (clojure.string/join "\n")))
+       (clojure.string/join "\n"))
+  )
 
 (defn- make-mws-auth-string-for-response [status body app-uuid time]
   (->> [status body app-uuid time]
-       (clojure.string/join "\n")))
+       (clojure.string/join "\n"))
+  )
 
 (defn build-mauth-headers
   ([verb url body app-uuid private-key]
-   (let [x-mws-time (epoch-seconds)
-         x-mws-authentication (make-mws-auth-string verb url body app-uuid x-mws-time)]
-     {"X-MWS-Authentication" (-> x-mws-authentication
-                                 msg->sha512
-                                 (sign-mauth app-uuid private-key))
-      "X-MWS-Time"           (str x-mws-time)}))
+    (let [x-mws-time (epoch-seconds)
+          x-mws-authentication (make-mws-auth-string verb url body app-uuid x-mws-time)]
+      {"X-MWS-Authentication" (-> x-mws-authentication
+                                  msg->sha512
+                                  (sign-mauth app-uuid private-key))
+       "X-MWS-Time"           (str x-mws-time)}))
   ([status body app-uuid private-key]
    (let [x-mws-time (epoch-seconds)
          x-mws-authentication (make-mws-auth-string-for-response status body app-uuid x-mws-time)]
      {"X-MWS-Authentication" (-> x-mws-authentication
                                  msg->sha512
                                  (sign-mauth app-uuid private-key))
-      "X-MWS-Time"           (str x-mws-time)})))
+      "X-MWS-Time"           (str x-mws-time)}))
+  )
 
-(defn get-hex-encoded-digested-string [msg]
-  (msg->sha512 msg))
-
-(defn str->bytes
-  "Convert string to byte array."
-  ([^String s]
-   (str->bytes s "UTF-8"))
-  ([^String s, ^String encoding]
-   (.getBytes s encoding)))
-
-(defn encrypt-signature-rsa [private-key-string string-to-sign]
-  (let [signature-instance (signature/*get-instance "SHA256withRSA")
-        private-key (pem/private-key (read-key private-key-string))
-        byte-array-to-sign (str->bytes (String. string-to-sign))]
-    (signature/init-sign signature-instance private-key)
-    (signature/update signature-instance byte-array-to-sign 0 (alength byte-array-to-sign))
-    (->> (signature/sign signature-instance)
-         base64/encode
-         String.
-         (str ""))))
-
-(defn generate-headers-v2 [mcc-auth-string-to-sign app-uuid private-key]
-  (let [encrypted-signature (encrypt-signature-rsa private-key mcc-auth-string-to-sign)
-        mcc-authentication (str "MWSV2" " " app-uuid ":" encrypted-signature ";")]
-    mcc-authentication))
-
-(defn build-mauth-headers-v2
-  ([verb-or-status body app-uuid private-key]
-   (build-mauth-headers-v2 verb-or-status nil body app-uuid private-key nil))
-  ([verb-or-status url body app-uuid private-key query-param]
-   (let [mcc-time (epoch-seconds)
-         params-vec (if (instance? java.lang.String verb-or-status)
-                      [verb-or-status (get-uri url) (get-hex-encoded-digested-string body) app-uuid mcc-time query-param]
-                      [verb-or-status (get-hex-encoded-digested-string body) app-uuid mcc-time])
-         all-params-string (clojure.string/join "\n" params-vec)
-         authentication (generate-headers-v2 all-params-string app-uuid private-key)]
-     {"mcc-authentication" authentication
-      "mcc-time"           (str mcc-time)})))

--- a/src/clojure_mauth_client/header_v2.clj
+++ b/src/clojure_mauth_client/header_v2.clj
@@ -1,48 +1,13 @@
 (ns clojure-mauth-client.header-v2
   (:require [pem-reader.core :as pem]
             [clojure.data.codec.base64 :as base64]
-            [clojure.string :refer [blank?]]
-            [jdk.security.Signature :as signature])
-  (:use digest)
-  (:import (java.io ByteArrayInputStream)))
-
-(defn- epoch-seconds []
-  (long (/ (System/currentTimeMillis) 1000)))
-
-(defn- msg->sha512 [msg]
-  (-> msg
-      .getBytes
-      sha-512))
-
-(defn- get-uri [url]
-  (-> url
-      java.net.URL.
-      .getPath
-      (#(if (blank? %) "/" %))
-      )
-  )
-
-(defn- read-key [key-str]
-  (-> key-str
-      .getBytes
-      ByteArrayInputStream.
-      pem/read)
-  )
-
-(defn- get-hex-encoded-digested-string [msg]
-  (msg->sha512 msg))
-
-(defn- str->bytes
-  "Convert string to byte array."
-  ([^String s]
-   (str->bytes s "UTF-8"))
-  ([^String s, ^String encoding]
-   (.getBytes s encoding)))
+            [jdk.security.Signature :as signature]
+            [clojure-mauth-client.util :as util]))
 
 (defn- encrypt-signature-rsa [private-key-string string-to-sign]
   (let [signature-instance (signature/*get-instance "SHA256withRSA")
-        private-key (pem/private-key (read-key private-key-string))
-        byte-array-to-sign (str->bytes (String. string-to-sign))]
+        private-key (pem/private-key (util/read-key private-key-string))
+        byte-array-to-sign (util/str->bytes (String. string-to-sign))]
     (signature/init-sign signature-instance private-key)
     (signature/update signature-instance byte-array-to-sign 0 (alength byte-array-to-sign))
     (->> (signature/sign signature-instance)
@@ -59,10 +24,10 @@
   ([verb-or-status body app-uuid private-key]
    (build-mauth-headers-v2 verb-or-status nil body app-uuid private-key nil))
   ([verb-or-status url body app-uuid private-key query-param]
-   (let [mcc-time (epoch-seconds)
+   (let [mcc-time (util/epoch-seconds)
          params-vec (if (instance? java.lang.String verb-or-status)
-                      [verb-or-status (get-uri url) (get-hex-encoded-digested-string body) app-uuid mcc-time query-param]
-                      [verb-or-status (get-hex-encoded-digested-string body) app-uuid mcc-time])
+                      [verb-or-status (util/get-uri url) (util/get-hex-encoded-digested-string body) app-uuid mcc-time query-param]
+                      [verb-or-status (util/get-hex-encoded-digested-string body) app-uuid mcc-time])
          all-params-string (clojure.string/join "\n" params-vec)
          authentication (generate-headers-v2 all-params-string app-uuid private-key)]
      {"mcc-authentication" authentication

--- a/src/clojure_mauth_client/header_v2.clj
+++ b/src/clojure_mauth_client/header_v2.clj
@@ -1,0 +1,69 @@
+(ns clojure-mauth-client.header-v2
+  (:require [pem-reader.core :as pem]
+            [clojure.data.codec.base64 :as base64]
+            [clojure.string :refer [blank?]]
+            [jdk.security.Signature :as signature])
+  (:use digest)
+  (:import (java.io ByteArrayInputStream)))
+
+(defn- epoch-seconds []
+  (long (/ (System/currentTimeMillis) 1000)))
+
+(defn- msg->sha512 [msg]
+  (-> msg
+      .getBytes
+      sha-512))
+
+(defn- get-uri [url]
+  (-> url
+      java.net.URL.
+      .getPath
+      (#(if (blank? %) "/" %))
+      )
+  )
+
+(defn- read-key [key-str]
+  (-> key-str
+      .getBytes
+      ByteArrayInputStream.
+      pem/read)
+  )
+
+(defn- get-hex-encoded-digested-string [msg]
+  (msg->sha512 msg))
+
+(defn- str->bytes
+  "Convert string to byte array."
+  ([^String s]
+   (str->bytes s "UTF-8"))
+  ([^String s, ^String encoding]
+   (.getBytes s encoding)))
+
+(defn- encrypt-signature-rsa [private-key-string string-to-sign]
+  (let [signature-instance (signature/*get-instance "SHA256withRSA")
+        private-key (pem/private-key (read-key private-key-string))
+        byte-array-to-sign (str->bytes (String. string-to-sign))]
+    (signature/init-sign signature-instance private-key)
+    (signature/update signature-instance byte-array-to-sign 0 (alength byte-array-to-sign))
+    (->> (signature/sign signature-instance)
+         base64/encode
+         String.
+         (str ""))))
+
+(defn- generate-headers-v2 [mcc-auth-string-to-sign app-uuid private-key]
+  (let [encrypted-signature (encrypt-signature-rsa private-key mcc-auth-string-to-sign)
+        mcc-authentication (str "MWSV2" " " app-uuid ":" encrypted-signature ";")]
+    mcc-authentication))
+
+(defn build-mauth-headers-v2
+  ([verb-or-status body app-uuid private-key]
+   (build-mauth-headers-v2 verb-or-status nil body app-uuid private-key nil))
+  ([verb-or-status url body app-uuid private-key query-param]
+   (let [mcc-time (epoch-seconds)
+         params-vec (if (instance? java.lang.String verb-or-status)
+                      [verb-or-status (get-uri url) (get-hex-encoded-digested-string body) app-uuid mcc-time query-param]
+                      [verb-or-status (get-hex-encoded-digested-string body) app-uuid mcc-time])
+         all-params-string (clojure.string/join "\n" params-vec)
+         authentication (generate-headers-v2 all-params-string app-uuid private-key)]
+     {"mcc-authentication" authentication
+      "mcc-time"           (str mcc-time)})))

--- a/src/clojure_mauth_client/request.clj
+++ b/src/clojure_mauth_client/request.clj
@@ -14,18 +14,15 @@
     (.setSSLParameters ssl-engine ssl-params)))
 
 (defn build-header [mauth-version query-string params]
-      (let [params-with-query-string (conj params query-string)]
-           (if (not (seq mauth-version))
-             (apply build-mauth-headers params)
-             (if (^String .equalsIgnoreCase mauth-version "v2" )
-               (apply build-mauth-headers-v2 params-with-query-string)
-               (apply build-mauth-headers params)))))
-
+  (let [params-with-query-string (conj params query-string)]
+    (if (or (not (seq mauth-version)) (not (^String .equalsIgnoreCase mauth-version "v2")))
+      (apply build-mauth-headers params)
+      (apply build-mauth-headers-v2 params-with-query-string))))
 
 (defn make-request [type base-url uri body & {:keys [additional-headers with-sni? throw-exceptions?]
-                                               :or {additional-headers {}
-                                                    with-sni? nil
-                                                    throw-exceptions? false}}]
+                                              :or   {additional-headers {}
+                                                     with-sni?          nil
+                                                     throw-exceptions?  false}}]
   (let [cred (get-credentials)
         mauth-version (additional-headers :mauth-version)
         query-params (additional-headers :query-param-string)
@@ -36,37 +33,37 @@
                      (#(build-header mauth-version query-params %))
                      (merge additional-headers)
                      ; We use clj-http instead of http-kit because it is supported by the motel-java tracing agent
-                     (#(client/request (-> {:headers %
-                                          :url (str base-url uri)
-                                          :method (keyword (.toLowerCase type))
-                                          :body body
-                                          :throw-exceptions throw-exceptions?
-                                          :as :auto}
-                                         (merge options)))))]
+                     (#(client/request (-> {:headers          %
+                                            :url              (str base-url uri)
+                                            :method           (keyword (.toLowerCase type))
+                                            :body             body
+                                            :throw-exceptions throw-exceptions?
+                                            :as               :auto}
+                                           (merge options)))))]
     ; The following line is here because existing clients expect a String instead of a LazySeq.
     ; When we're ready to make a breaking change, we should return "response" directly with no modification.
     (update response :body json/write-str)))
 
 (defn get! [base-url uri & {:keys [additional-headers with-sni?]
-                            :or {additional-headers {}
-                                 with-sni? nil}}]
+                            :or   {additional-headers {}
+                                   with-sni?          nil}}]
   (make-request "GET" base-url uri "" :additional-headers additional-headers
-                                      :with-sni? with-sni?))
+                :with-sni? with-sni?))
 
 (defn post! [base-url uri body & {:keys [additional-headers with-sni?]
-                                  :or {additional-headers {}
-                                       with-sni? nil}}]
+                                  :or   {additional-headers {}
+                                         with-sni?          nil}}]
   (make-request "POST" base-url uri body :additional-headers additional-headers
-                                         :with-sni? with-sni?))
+                :with-sni? with-sni?))
 
 (defn delete! [base-url uri & {:keys [additional-headers with-sni?]
-                               :or {additional-headers {}
-                                    with-sni? nil}}]
+                               :or   {additional-headers {}
+                                      with-sni?          nil}}]
   (make-request "DELETE" base-url uri "" :additional-headers additional-headers
-                                         :with-sni? with-sni?))
+                :with-sni? with-sni?))
 
 (defn put! [base-url uri body & {:keys [additional-headers with-sni?]
-                                 :or {additional-headers {}
-                                      with-sni? nil}}]
+                                 :or   {additional-headers {}
+                                        with-sni?          nil}}]
   (make-request "PUT" base-url uri body :additional-headers additional-headers
-                                        :with-sni? with-sni?))
+                :with-sni? with-sni?))

--- a/src/clojure_mauth_client/request.clj
+++ b/src/clojure_mauth_client/request.clj
@@ -1,10 +1,10 @@
 (ns clojure-mauth-client.request
   (:require [org.httpkit.client :as http]
             [clj-http.client :as client]
-            [clojure.data.json :as json])
-  (:use clojure-mauth-client.header
-        clojure-mauth-client.header-v2
-        clojure-mauth-client.credentials)
+            [clojure.data.json :as json]
+            [clojure-mauth-client.header :as header]
+            [clojure-mauth-client.header-v2 :as header-v2]
+            [clojure-mauth-client.credentials :as credentials])
   (:import (javax.net.ssl SSLEngine SNIHostName SSLParameters)
            (java.net URI)))
 
@@ -17,14 +17,14 @@
 (defn build-header [mauth-version query-string params]
   (let [params-with-query-string (conj params query-string)]
     (if (or (not (seq mauth-version)) (not (^String .equalsIgnoreCase mauth-version "v2")))
-      (apply build-mauth-headers params)
-      (apply build-mauth-headers-v2 params-with-query-string))))
+      (apply header/build-mauth-headers params)
+      (apply header-v2/build-mauth-headers-v2 params-with-query-string))))
 
 (defn make-request [type base-url uri body & {:keys [additional-headers with-sni? throw-exceptions?]
                                               :or   {additional-headers {}
                                                      with-sni?          nil
                                                      throw-exceptions?  false}}]
-  (let [cred (get-credentials)
+  (let [cred (credentials/get-credentials)
         mauth-version (additional-headers :mauth-version)
         query-params (additional-headers :query-param-string)
         ; Tech debt: test with-sni?=true and modify this code if needed

--- a/src/clojure_mauth_client/request.clj
+++ b/src/clojure_mauth_client/request.clj
@@ -3,6 +3,7 @@
             [clj-http.client :as client]
             [clojure.data.json :as json])
   (:use clojure-mauth-client.header
+        clojure-mauth-client.header-v2
         clojure-mauth-client.credentials)
   (:import (javax.net.ssl SSLEngine SNIHostName SSLParameters)
            (java.net URI)))

--- a/src/clojure_mauth_client/util.clj
+++ b/src/clojure_mauth_client/util.clj
@@ -1,0 +1,36 @@
+(ns clojure-mauth-client.util
+  (:require [clojure.string :refer [blank?]]
+            [pem-reader.core :as pem])
+  (:use digest)
+  (:import (java.io ByteArrayInputStream)))
+
+(defn epoch-seconds []
+  (long (/ (System/currentTimeMillis) 1000)))
+
+(defn msg->sha512 [msg]
+  (-> msg
+      .getBytes
+      sha-512))
+
+(defn get-uri [url]
+  (-> url
+      java.net.URL.
+      .getPath
+      (#(if (blank? %) "/" %))))
+
+(defn read-key [key-str]
+  (-> key-str
+      .getBytes
+      ByteArrayInputStream.
+      pem/read))
+
+(defn get-hex-encoded-digested-string [msg]
+  (msg->sha512 msg))
+
+(defn str->bytes
+  "Convert string to byte array."
+  ([^String s]
+   (str->bytes s "UTF-8"))
+  ([^String s, ^String encoding]
+   (.getBytes s encoding)))
+

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -37,9 +37,7 @@
                         -----END RSA PRIVATE KEY-----"
                         "https://mauth-sandbox.imedidata.net")
     (with-redefs [clojure-mauth-client.header/epoch-seconds (fn [] 1532825948)]
-      (f)
-      )
-    ))
+      (f))))
 
 (deftest header-test
   (testing "It should generate a valid mauth X-MWS header for GET"
@@ -47,19 +45,14 @@
       (-> (build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))
           (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
               "X-MWS-Time"           "1532825948"})
-          is
-          )
-      ))
+          is)))
+
   (testing "It should generate a valid mauth X-MWS header for response"
     (let [creds (get-credentials)]
       (-> (build-mauth-headers 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))
           (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:i0rLrgEN8Jy/M4kA1PNNckUxeGU2pL3PGCOjdhRrC6egHVTvNfJLXveVG/7wAU9H4hpLYsThyV1/LRc/OupBZmKYRDzqD6OneZVLkysehk6/OHKb8j8uJQnBSLB72ooIPPIUxJqtasHCi6cdzkBEZf3omp7qzkinhuX2Wi/t70xfC5YmeTydBoe2d+zcIDJZb6+zON4V5CwGMPlCLK6iFD8+hk9ddhszQZ+siHK8SWxrhrMGRDN9xyp3ljw+f62tlpTZi0KEHAr0M/aq49aP3Iv/XrN88Cl5Tt1nGIWslarfJrAxFNfzofO0KULqFB9nRV1NkBbrSMyjGvea7nGNBw=="
               "X-MWS-Time"           "1532825948"})
-          is
-          )
-      )
-    )
-  )
+          is))))
 
 (deftest header-v2-test
          (testing "It should generate a valid mauth MWSV2 header for POST"
@@ -67,13 +60,11 @@
              (-> (build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")
                   (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:WG3mMzhcRAm0zYntF8pfYaMjVB3Z9O29XpqvmJ935yZaUTQBjRYVJj2cZo/fU+bMGesMTNLH/aCXLIj9h+h/9ni/hWC2r0C+23qzRpd6JFyy9eFCa1h1JxMrIBSQOC4ESnDl1Wki177TSUYKc43aeM/bJjNBDDtpoazIjGM45G7tSmCNTy+7ORtoubo8W4GTc6hwVA0IhkxCbOjW9iJ40Nruju8BZ9ZSmfO/CfhtkzCEeXnUe542w3AfQMoqnOtDQeZNuU+7xRYMb0L3bSHYRd6WQek7Adk6maAkbCAdXQnAJ+sl78/Sf3yPruSqTwwPuYTPforWv/u3DyhEgXbPjw==;"
                       "mcc-time"           "1532825948"})
-                   is
-                   )))
+                   is)))
 
          (testing "It should generate a valid mauth MWSV2 header for response"
            (let [creds (get-credentials)]
               (-> (build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))
                    (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
                        "mcc-time"           "1532825948"})
-                    is
-                    ))))
+                    is))))

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -1,13 +1,14 @@
 (ns clojure-mauth-client.header-test
   (:require [clojure.test :refer :all]
-            [clojure-mauth-client.header :refer :all])
-  (:use [clojure-mauth-client.credentials]))
+            [clojure-mauth-client.header :as header]
+            [clojure-mauth-client.util :as util]
+            [clojure-mauth-client.credentials :as credentials]))
 
 (use-fixtures
   :once
   (fn [f]
     ;Note: these are NOT valid real credentials.
-    (define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
+    (credentials/define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
                         "-----BEGIN RSA PRIVATE KEY-----
                         MIIEowIBAAKCAQEAsaa4gcNl4jx9YF7Y/6B+v29c0KBs1vxym0p4hwjZl5GteQgR
                         uFW5wM93F2lUFiVEQoM+Ti3AQjEDWdeuOIfo66LgbNLH7B3JhbkwHti/bMsq7T66
@@ -36,19 +37,19 @@
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
                         "https://mauth-sandbox.imedidata.net")
-    (with-redefs [clojure-mauth-client.header/epoch-seconds (fn [] 1532825948)]
+    (with-redefs [util/epoch-seconds (fn [] 1532825948)]
       (f))))
 
 (deftest header-test
   (testing "It should generate a valid mauth X-MWS header for GET"
-    (let [creds (get-credentials)
-          mauth-headers (build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))]
+    (let [creds (credentials/get-credentials)
+          mauth-headers (header/build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))]
       (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
               "X-MWS-Time"           "1532825948"}))))
 
   (testing "It should generate a valid mauth X-MWS header for response"
-    (let [creds (get-credentials)
-          mauth-headers (build-mauth-headers 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
+    (let [creds (credentials/get-credentials)
+          mauth-headers (header/build-mauth-headers 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
       (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:i0rLrgEN8Jy/M4kA1PNNckUxeGU2pL3PGCOjdhRrC6egHVTvNfJLXveVG/7wAU9H4hpLYsThyV1/LRc/OupBZmKYRDzqD6OneZVLkysehk6/OHKb8j8uJQnBSLB72ooIPPIUxJqtasHCi6cdzkBEZf3omp7qzkinhuX2Wi/t70xfC5YmeTydBoe2d+zcIDJZb6+zON4V5CwGMPlCLK6iFD8+hk9ddhszQZ+siHK8SWxrhrMGRDN9xyp3ljw+f62tlpTZi0KEHAr0M/aq49aP3Iv/XrN88Cl5Tt1nGIWslarfJrAxFNfzofO0KULqFB9nRV1NkBbrSMyjGvea7nGNBw=="
               "X-MWS-Time"           "1532825948"} mauth-headers)))))
 

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -60,3 +60,20 @@
       )
     )
   )
+
+(deftest header-v2-test
+         (testing "It should generate a valid mauth MWSV2 header for POST"
+           (let [creds (get-credentials)]
+             (-> (build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")
+                  (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:WG3mMzhcRAm0zYntF8pfYaMjVB3Z9O29XpqvmJ935yZaUTQBjRYVJj2cZo/fU+bMGesMTNLH/aCXLIj9h+h/9ni/hWC2r0C+23qzRpd6JFyy9eFCa1h1JxMrIBSQOC4ESnDl1Wki177TSUYKc43aeM/bJjNBDDtpoazIjGM45G7tSmCNTy+7ORtoubo8W4GTc6hwVA0IhkxCbOjW9iJ40Nruju8BZ9ZSmfO/CfhtkzCEeXnUe542w3AfQMoqnOtDQeZNuU+7xRYMb0L3bSHYRd6WQek7Adk6maAkbCAdXQnAJ+sl78/Sf3yPruSqTwwPuYTPforWv/u3DyhEgXbPjw==;"
+                      "mcc-time"           "1532825948"})
+                   is
+                   )))
+
+         (testing "It should generate a valid mauth MWSV2 header for response"
+           (let [creds (get-credentials)]
+              (-> (build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))
+                   (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
+                       "mcc-time"           "1532825948"})
+                    is
+                    ))))

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -61,6 +61,6 @@
 
   (testing "It should generate a valid mauth MWSV2 header for response"
     (let [creds (get-credentials)
-          mauth-headers-v2 (build-mauth-response-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
+          mauth-headers-v2 (build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
       (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
               "mcc-time"           "1532825948"} mauth-headers-v2)))))

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -41,30 +41,26 @@
 
 (deftest header-test
   (testing "It should generate a valid mauth X-MWS header for GET"
-    (let [creds (get-credentials)]
-      (-> (build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))
-          (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
-              "X-MWS-Time"           "1532825948"})
-          is)))
+    (let [creds (get-credentials)
+          mauth-headers (build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))]
+      (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
+              "X-MWS-Time"           "1532825948"}))))
 
   (testing "It should generate a valid mauth X-MWS header for response"
-    (let [creds (get-credentials)]
-      (-> (build-mauth-headers 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))
-          (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:i0rLrgEN8Jy/M4kA1PNNckUxeGU2pL3PGCOjdhRrC6egHVTvNfJLXveVG/7wAU9H4hpLYsThyV1/LRc/OupBZmKYRDzqD6OneZVLkysehk6/OHKb8j8uJQnBSLB72ooIPPIUxJqtasHCi6cdzkBEZf3omp7qzkinhuX2Wi/t70xfC5YmeTydBoe2d+zcIDJZb6+zON4V5CwGMPlCLK6iFD8+hk9ddhszQZ+siHK8SWxrhrMGRDN9xyp3ljw+f62tlpTZi0KEHAr0M/aq49aP3Iv/XrN88Cl5Tt1nGIWslarfJrAxFNfzofO0KULqFB9nRV1NkBbrSMyjGvea7nGNBw=="
-              "X-MWS-Time"           "1532825948"})
-          is))))
+    (let [creds (get-credentials)
+          mauth-headers (build-mauth-headers 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
+      (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:i0rLrgEN8Jy/M4kA1PNNckUxeGU2pL3PGCOjdhRrC6egHVTvNfJLXveVG/7wAU9H4hpLYsThyV1/LRc/OupBZmKYRDzqD6OneZVLkysehk6/OHKb8j8uJQnBSLB72ooIPPIUxJqtasHCi6cdzkBEZf3omp7qzkinhuX2Wi/t70xfC5YmeTydBoe2d+zcIDJZb6+zON4V5CwGMPlCLK6iFD8+hk9ddhszQZ+siHK8SWxrhrMGRDN9xyp3ljw+f62tlpTZi0KEHAr0M/aq49aP3Iv/XrN88Cl5Tt1nGIWslarfJrAxFNfzofO0KULqFB9nRV1NkBbrSMyjGvea7nGNBw=="
+              "X-MWS-Time"           "1532825948"} mauth-headers)))))
 
 (deftest header-v2-test
-         (testing "It should generate a valid mauth MWSV2 header for POST"
-           (let [creds (get-credentials)]
-             (-> (build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")
-                  (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:WG3mMzhcRAm0zYntF8pfYaMjVB3Z9O29XpqvmJ935yZaUTQBjRYVJj2cZo/fU+bMGesMTNLH/aCXLIj9h+h/9ni/hWC2r0C+23qzRpd6JFyy9eFCa1h1JxMrIBSQOC4ESnDl1Wki177TSUYKc43aeM/bJjNBDDtpoazIjGM45G7tSmCNTy+7ORtoubo8W4GTc6hwVA0IhkxCbOjW9iJ40Nruju8BZ9ZSmfO/CfhtkzCEeXnUe542w3AfQMoqnOtDQeZNuU+7xRYMb0L3bSHYRd6WQek7Adk6maAkbCAdXQnAJ+sl78/Sf3yPruSqTwwPuYTPforWv/u3DyhEgXbPjw==;"
-                      "mcc-time"           "1532825948"})
-                   is)))
+  (testing "It should generate a valid mauth MWSV2 header for POST"
+    (let [creds (get-credentials)
+          mauth-header-v2 (build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")]
+      (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:WG3mMzhcRAm0zYntF8pfYaMjVB3Z9O29XpqvmJ935yZaUTQBjRYVJj2cZo/fU+bMGesMTNLH/aCXLIj9h+h/9ni/hWC2r0C+23qzRpd6JFyy9eFCa1h1JxMrIBSQOC4ESnDl1Wki177TSUYKc43aeM/bJjNBDDtpoazIjGM45G7tSmCNTy+7ORtoubo8W4GTc6hwVA0IhkxCbOjW9iJ40Nruju8BZ9ZSmfO/CfhtkzCEeXnUe542w3AfQMoqnOtDQeZNuU+7xRYMb0L3bSHYRd6WQek7Adk6maAkbCAdXQnAJ+sl78/Sf3yPruSqTwwPuYTPforWv/u3DyhEgXbPjw==;"
+              "mcc-time"           "1532825948"} mauth-header-v2))))
 
-         (testing "It should generate a valid mauth MWSV2 header for response"
-           (let [creds (get-credentials)]
-              (-> (build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))
-                   (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
-                       "mcc-time"           "1532825948"})
-                    is))))
+  (testing "It should generate a valid mauth MWSV2 header for response"
+    (let [creds (get-credentials)
+          mauth-headers-v2 (build-mauth-response-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
+      (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
+              "mcc-time"           "1532825948"} mauth-headers-v2)))))

--- a/test/clojure_mauth_client/header_v2_test.clj
+++ b/test/clojure_mauth_client/header_v2_test.clj
@@ -1,6 +1,6 @@
-(ns clojure-mauth-client.header-test
+(ns clojure-mauth-client.header-v2-test
   (:require [clojure.test :refer :all]
-            [clojure-mauth-client.header :refer :all])
+            [clojure-mauth-client.header-v2 :refer :all])
   (:use [clojure-mauth-client.credentials]))
 
 (use-fixtures
@@ -36,19 +36,19 @@
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
                         "https://mauth-sandbox.imedidata.net")
-    (with-redefs [clojure-mauth-client.header/epoch-seconds (fn [] 1532825948)]
+    (with-redefs [clojure-mauth-client.header-v2/epoch-seconds (fn [] 1532825948)]
       (f))))
 
-(deftest header-test
-  (testing "It should generate a valid mauth X-MWS header for GET"
-    (let [creds (get-credentials)
-          mauth-headers (build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))]
-      (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
-              "X-MWS-Time"           "1532825948"}))))
 
-  (testing "It should generate a valid mauth X-MWS header for response"
+(deftest header-v2-test
+  (testing "It should generate a valid mauth MWSV2 header for POST"
     (let [creds (get-credentials)
-          mauth-headers (build-mauth-headers 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
-      (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:i0rLrgEN8Jy/M4kA1PNNckUxeGU2pL3PGCOjdhRrC6egHVTvNfJLXveVG/7wAU9H4hpLYsThyV1/LRc/OupBZmKYRDzqD6OneZVLkysehk6/OHKb8j8uJQnBSLB72ooIPPIUxJqtasHCi6cdzkBEZf3omp7qzkinhuX2Wi/t70xfC5YmeTydBoe2d+zcIDJZb6+zON4V5CwGMPlCLK6iFD8+hk9ddhszQZ+siHK8SWxrhrMGRDN9xyp3ljw+f62tlpTZi0KEHAr0M/aq49aP3Iv/XrN88Cl5Tt1nGIWslarfJrAxFNfzofO0KULqFB9nRV1NkBbrSMyjGvea7nGNBw=="
-              "X-MWS-Time"           "1532825948"} mauth-headers)))))
+          mauth-header-v2 (build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")]
+      (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:WG3mMzhcRAm0zYntF8pfYaMjVB3Z9O29XpqvmJ935yZaUTQBjRYVJj2cZo/fU+bMGesMTNLH/aCXLIj9h+h/9ni/hWC2r0C+23qzRpd6JFyy9eFCa1h1JxMrIBSQOC4ESnDl1Wki177TSUYKc43aeM/bJjNBDDtpoazIjGM45G7tSmCNTy+7ORtoubo8W4GTc6hwVA0IhkxCbOjW9iJ40Nruju8BZ9ZSmfO/CfhtkzCEeXnUe542w3AfQMoqnOtDQeZNuU+7xRYMb0L3bSHYRd6WQek7Adk6maAkbCAdXQnAJ+sl78/Sf3yPruSqTwwPuYTPforWv/u3DyhEgXbPjw==;"
+              "mcc-time"           "1532825948"} mauth-header-v2))))
 
+  (testing "It should generate a valid mauth MWSV2 header for response"
+    (let [creds (get-credentials)
+          mauth-headers-v2 (build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
+      (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
+              "mcc-time"           "1532825948"} mauth-headers-v2)))))

--- a/test/clojure_mauth_client/header_v2_test.clj
+++ b/test/clojure_mauth_client/header_v2_test.clj
@@ -1,13 +1,14 @@
 (ns clojure-mauth-client.header-v2-test
   (:require [clojure.test :refer :all]
-            [clojure-mauth-client.header-v2 :refer :all])
-  (:use [clojure-mauth-client.credentials]))
+            [clojure-mauth-client.header-v2 :as header-v2]
+            [clojure-mauth-client.credentials :as credentials]
+            [clojure-mauth-client.util :as util]))
 
 (use-fixtures
   :once
   (fn [f]
     ;Note: these are NOT valid real credentials.
-    (define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
+    (credentials/define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
                         "-----BEGIN RSA PRIVATE KEY-----
                         MIIEowIBAAKCAQEAsaa4gcNl4jx9YF7Y/6B+v29c0KBs1vxym0p4hwjZl5GteQgR
                         uFW5wM93F2lUFiVEQoM+Ti3AQjEDWdeuOIfo66LgbNLH7B3JhbkwHti/bMsq7T66
@@ -36,19 +37,19 @@
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
                         "https://mauth-sandbox.imedidata.net")
-    (with-redefs [clojure-mauth-client.header-v2/epoch-seconds (fn [] 1532825948)]
+    (with-redefs [util/epoch-seconds (fn [] 1532825948)]
       (f))))
 
 
 (deftest header-v2-test
   (testing "It should generate a valid mauth MWSV2 header for POST"
-    (let [creds (get-credentials)
-          mauth-header-v2 (build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")]
+    (let [creds (credentials/get-credentials)
+          mauth-header-v2 (header-v2/build-mauth-headers-v2 "POST" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds) "abc=testing&test=1234")]
       (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:WG3mMzhcRAm0zYntF8pfYaMjVB3Z9O29XpqvmJ935yZaUTQBjRYVJj2cZo/fU+bMGesMTNLH/aCXLIj9h+h/9ni/hWC2r0C+23qzRpd6JFyy9eFCa1h1JxMrIBSQOC4ESnDl1Wki177TSUYKc43aeM/bJjNBDDtpoazIjGM45G7tSmCNTy+7ORtoubo8W4GTc6hwVA0IhkxCbOjW9iJ40Nruju8BZ9ZSmfO/CfhtkzCEeXnUe542w3AfQMoqnOtDQeZNuU+7xRYMb0L3bSHYRd6WQek7Adk6maAkbCAdXQnAJ+sl78/Sf3yPruSqTwwPuYTPforWv/u3DyhEgXbPjw==;"
               "mcc-time"           "1532825948"} mauth-header-v2))))
 
   (testing "It should generate a valid mauth MWSV2 header for response"
-    (let [creds (get-credentials)
-          mauth-headers-v2 (build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
+    (let [creds (credentials/get-credentials)
+          mauth-headers-v2 (header-v2/build-mauth-headers-v2 200 "{\"test\":\"testing\"}" (:app-uuid creds) (:private-key creds))]
       (is (= {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:LFpZhmJRnEoO7/S862U7OhGEFPtMv332pJ0LflJGYBrNRB67XkbTG+/bDDWrF0bWwZ8Z6rJjUhfDUj6xjUoNYlsuQZrVi1x79+uYs/NUasRAp2e4zRnxDCtwzBP6bf/MVxlDUi87Vf4Ko+mXSzGZXRnJVktbOccfNVbvZxUfoq7UxwHsopxJvakQ3ZNZw+G7nxPRwFxEkDuuZGKV0Oq6ujqL+6ydy9RM2Z44J0Tvpf9GXeq0dlWrJDJEULyOM4NrLVPS2m7CJX3rffnUOSbO0UebmS6kRJNgFqKJ58NOAF9bop4S9BUuEdn1k4kt0ol8HZu8rkIyCZSAZIh80opE5g==;"
               "mcc-time"           "1532825948"} mauth-headers-v2)))))

--- a/test/clojure_mauth_client/request_test.clj
+++ b/test/clojure_mauth_client/request_test.clj
@@ -1,7 +1,8 @@
 (ns clojure-mauth-client.request-test
   (:require [clojure.test :refer :all]
             [clojure-mauth-client.request :refer :all]
-            [clojure.data.json :as json])
+            [clojure.data.json :as json]
+            [clojure-mauth-client.util :as util])
   (:use [clojure-mauth-client.credentials]))
 
 (use-fixtures
@@ -38,8 +39,7 @@
                         -----END RSA PRIVATE KEY-----"
                         "https://mauth-sandbox.imedidata.net")
 
-    (with-redefs [clojure-mauth-client.header/epoch-seconds (fn [] 1532825948)
-                  clojure-mauth-client.header-v2/epoch-seconds (fn [] 1532825948)
+    (with-redefs [util/epoch-seconds (fn [] 1532825948)
                   clj-http.client/request (fn [{:keys [client timeout filter worker-pool keepalive as follow-redirects max-redirects response
                                                        trace-redirects allow-unsafe-redirect-methods proxy-host proxy-port tunnel?]
                                                 :as   opts

--- a/test/clojure_mauth_client/request_test.clj
+++ b/test/clojure_mauth_client/request_test.clj
@@ -103,70 +103,70 @@
    :as               :auto})
 
 (def mock-post-v2
-  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfmLrKcQkr2KnO03jFGALsOXpPSAFWgsbP0TvfvwraW7nveyRqXgzDVSFM23kG2bku319Cm5OBtikQHLYZo6BRMZZ+iGvAGh3XEs6dlAlaFLvzvgGn+TFJqbQCbMoeb87UHEif4aLLLIQW3B4GuMFVzU3dqT1jrmte3GBhlEfoKiQiaXMRmEHI+y3rrg7uWSNXLEwmgzygHTRsGD4Mgt8QHd4sprY3M6In/kmPveztAKntFDDteb2YsTck0pyTgh3mi5r0sIEdHcsGhxeO+utgDt3vPUI8QcPvBICuy8BouXVWnDAv6HzQ26og==;"
-             "mcc-time"      "1532825948"
-             :Content-Type "application/json"
-             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-             :mauth-version "v2"
-             }
-   :url "https://www.mdsol.com/api/v2/testing1"
-   :method :post
-   :body "\"{\\\"a\\\":{\\\"b\\\":123}}\""
+  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfmLrKcQkr2KnO03jFGALsOXpPSAFWgsbP0TvfvwraW7nveyRqXgzDVSFM23kG2bku319Cm5OBtikQHLYZo6BRMZZ+iGvAGh3XEs6dlAlaFLvzvgGn+TFJqbQCbMoeb87UHEif4aLLLIQW3B4GuMFVzU3dqT1jrmte3GBhlEfoKiQiaXMRmEHI+y3rrg7uWSNXLEwmgzygHTRsGD4Mgt8QHd4sprY3M6In/kmPveztAKntFDDteb2YsTck0pyTgh3mi5r0sIEdHcsGhxeO+utgDt3vPUI8QcPvBICuy8BouXVWnDAv6HzQ26og==;"
+                      "mcc-time"           "1532825948"
+                      :Content-Type        "application/json"
+                      :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                      :mauth-version       "v2"
+                      }
+   :url              "https://www.mdsol.com/api/v2/testing1"
+   :method           :post
+   :body             "\"{\\\"a\\\":{\\\"b\\\":123}}\""
    :throw-exceptions false
-   :as :auto})
+   :as               :auto})
 
 (def mock-put-v2
-  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:JxNEVDUfC2iV2dNZ+p9bbP/efQaDEYvp1Y6LY7svXE+S4uF1sfOBw296iO3/sDYNm/eQz6OY6o+A0ti4L9kBpQgRqbSq6Q673gLEYOMrCswqMCM0uxJ1g95RBADgZVIg0ssjoSBU8lo1OXxjwhxz17PnDN+KTqw10DT2aiecmbhvvMVj3zAxG0vb9xxkIqYEFFkBolLoevriCL5PLqR8o2H1LmJ4eVvnR0HFetZyFEJM9KNxcQ1H8xYM8bZiocjLwPbCBk2IP3MRmgoeosTSgcAVRw7+7QRIpigz4kfc5pxHTuIa6k8voHyVzpW5uBolUBu7O1CvSgPVn2q/y+qrTQ==;"
-             "mcc-time"      "1532825948"
-             :Content-Type "application/json"
-             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-             :mauth-version "v2"
-             }
-   :url "https://www.mdsol.com/api/v2/testing1"
-   :method :put
-   :body "\"{\\\"a\\\":{\\\"b\\\":123}}\""
+  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:JxNEVDUfC2iV2dNZ+p9bbP/efQaDEYvp1Y6LY7svXE+S4uF1sfOBw296iO3/sDYNm/eQz6OY6o+A0ti4L9kBpQgRqbSq6Q673gLEYOMrCswqMCM0uxJ1g95RBADgZVIg0ssjoSBU8lo1OXxjwhxz17PnDN+KTqw10DT2aiecmbhvvMVj3zAxG0vb9xxkIqYEFFkBolLoevriCL5PLqR8o2H1LmJ4eVvnR0HFetZyFEJM9KNxcQ1H8xYM8bZiocjLwPbCBk2IP3MRmgoeosTSgcAVRw7+7QRIpigz4kfc5pxHTuIa6k8voHyVzpW5uBolUBu7O1CvSgPVn2q/y+qrTQ==;"
+                      "mcc-time"           "1532825948"
+                      :Content-Type        "application/json"
+                      :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                      :mauth-version       "v2"
+                      }
+   :url              "https://www.mdsol.com/api/v2/testing1"
+   :method           :put
+   :body             "\"{\\\"a\\\":{\\\"b\\\":123}}\""
    :throw-exceptions false
-   :as :auto})
+   :as               :auto})
 
 (def mock-get-v2
-  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:VELmFCqhoonHjj53gW0u2k2Ot30TU21CrWuzvIIR6FscCUdLMIRdK63lS3sLizkGH/X3YdlTLu3i67/Iw0SqkD2WzbkDHk00OP2Vf9S5ZLjkrFbkQgd8m4Kf0b1qmepXpHs2rZOnKep2/CIIZCHbitDe07oaNyI0ta+pZ76FKjbdsLS3BEUm5tW12eTlQkibeGuPb0yyso516x7Ya82lva4cTlZkIv4VfnVOtZs72BoL89uQsP7VflkYTP3aHMBZN90h6jjxKfZhF/I5Uo1W42Ci9I6i8SSa3O7g3M4msILxQzreVV0VYLg0ee+Vslu1T7cvXxmy9ZlfMMxf3H6LUg==;"
-             "mcc-time" "1532825948"
-             :Content-Type "application/json"
-             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-             :mauth-version "v2"
-             }
-   :url "https://www.mdsol.com/api/v2/testing1"
-   :method :get
-   :body "\"\""
+  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:VELmFCqhoonHjj53gW0u2k2Ot30TU21CrWuzvIIR6FscCUdLMIRdK63lS3sLizkGH/X3YdlTLu3i67/Iw0SqkD2WzbkDHk00OP2Vf9S5ZLjkrFbkQgd8m4Kf0b1qmepXpHs2rZOnKep2/CIIZCHbitDe07oaNyI0ta+pZ76FKjbdsLS3BEUm5tW12eTlQkibeGuPb0yyso516x7Ya82lva4cTlZkIv4VfnVOtZs72BoL89uQsP7VflkYTP3aHMBZN90h6jjxKfZhF/I5Uo1W42Ci9I6i8SSa3O7g3M4msILxQzreVV0VYLg0ee+Vslu1T7cvXxmy9ZlfMMxf3H6LUg==;"
+                      "mcc-time"           "1532825948"
+                      :Content-Type        "application/json"
+                      :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                      :mauth-version       "v2"
+                      }
+   :url              "https://www.mdsol.com/api/v2/testing1"
+   :method           :get
+   :body             "\"\""
    :throw-exceptions false
-   :as :auto})
+   :as               :auto})
 
 (def mock-get-with-qs-v2
-  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:VELmFCqhoonHjj53gW0u2k2Ot30TU21CrWuzvIIR6FscCUdLMIRdK63lS3sLizkGH/X3YdlTLu3i67/Iw0SqkD2WzbkDHk00OP2Vf9S5ZLjkrFbkQgd8m4Kf0b1qmepXpHs2rZOnKep2/CIIZCHbitDe07oaNyI0ta+pZ76FKjbdsLS3BEUm5tW12eTlQkibeGuPb0yyso516x7Ya82lva4cTlZkIv4VfnVOtZs72BoL89uQsP7VflkYTP3aHMBZN90h6jjxKfZhF/I5Uo1W42Ci9I6i8SSa3O7g3M4msILxQzreVV0VYLg0ee+Vslu1T7cvXxmy9ZlfMMxf3H6LUg==;"             "mcc-time" "1532825948"
-             :Content-Type "application/json"
-             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-             :mauth-version "v2"
-             }
-   :url "https://www.mdsol.com/api/v2/testing1?testABCD=1234"
-   :method :get
-   :body "\"\""
+  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:VELmFCqhoonHjj53gW0u2k2Ot30TU21CrWuzvIIR6FscCUdLMIRdK63lS3sLizkGH/X3YdlTLu3i67/Iw0SqkD2WzbkDHk00OP2Vf9S5ZLjkrFbkQgd8m4Kf0b1qmepXpHs2rZOnKep2/CIIZCHbitDe07oaNyI0ta+pZ76FKjbdsLS3BEUm5tW12eTlQkibeGuPb0yyso516x7Ya82lva4cTlZkIv4VfnVOtZs72BoL89uQsP7VflkYTP3aHMBZN90h6jjxKfZhF/I5Uo1W42Ci9I6i8SSa3O7g3M4msILxQzreVV0VYLg0ee+Vslu1T7cvXxmy9ZlfMMxf3H6LUg==;" "mcc-time" "1532825948"
+                      :Content-Type        "application/json"
+                      :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                      :mauth-version       "v2"
+                      }
+   :url              "https://www.mdsol.com/api/v2/testing1?testABCD=1234"
+   :method           :get
+   :body             "\"\""
    :throw-exceptions false
-   :as :auto})
+   :as               :auto})
 
 (def mock-delete-v2
-  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:rQR2OK8w3ixCyVqMZCxzUcEObaigSLfoHSgiGbONc0MD7GrhZ3rLLefV3nUaf3g/0hQi3Irx07NU+yBNS37Orya8eufqwsod1P2FeutNbHVLFhjTG+D/+StknEemQfzV7ZZ3abejzc02QP2QWn9jUk9sQjhByPcVbxapwnM2JAj5hCKmm1hE5UsJBk6YW59gWpTUPGGkDlp39LZfTV0lDOc402STy5h56FZSd9I92LA78f6ojF2izYlmp6Q+12FjuWARn9bjBPewRk8cKhYUs3fVl4ZEFwMyQM759waX9VASE9e/UCiFZTbZL2tCrvIRFys5FYmTy53A1pYZGjJ7Kw==;"
-             "mcc-time" "1532825948"
-             :Content-Type "application/json"
-             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-             :mauth-version "v2"
-             }
-   :url "https://www.mdsol.com/api/v2/testing1"
-   :method :delete
-   :body "\"\""
+  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:rQR2OK8w3ixCyVqMZCxzUcEObaigSLfoHSgiGbONc0MD7GrhZ3rLLefV3nUaf3g/0hQi3Irx07NU+yBNS37Orya8eufqwsod1P2FeutNbHVLFhjTG+D/+StknEemQfzV7ZZ3abejzc02QP2QWn9jUk9sQjhByPcVbxapwnM2JAj5hCKmm1hE5UsJBk6YW59gWpTUPGGkDlp39LZfTV0lDOc402STy5h56FZSd9I92LA78f6ojF2izYlmp6Q+12FjuWARn9bjBPewRk8cKhYUs3fVl4ZEFwMyQM759waX9VASE9e/UCiFZTbZL2tCrvIRFys5FYmTy53A1pYZGjJ7Kw==;"
+                      "mcc-time"           "1532825948"
+                      :Content-Type        "application/json"
+                      :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                      :mauth-version       "v2"
+                      }
+   :url              "https://www.mdsol.com/api/v2/testing1"
+   :method           :delete
+   :body             "\"\""
    :throw-exceptions false
-   :as :auto})
+   :as               :auto})
 
-(def additional-headers {:Content-Type "application/json"
+(def additional-headers {:Content-Type  "application/json"
                          :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
                          :mauth-version "v2"})
 
@@ -175,68 +175,57 @@
 
 (deftest header-test
   (testing "It should make a valid GET request."
-    (let [creds (get-credentials)]
-      (-> (get! "https://www.mdsol.com" "/api/v2/testing")
-          (= mock-get)
-          is)))
+    (let [creds (get-credentials)
+          get-response (get! "https://www.mdsol.com" "/api/v2/testing")]
+      (is (= mock-get get-response))))
 
   (testing "It should make a valid GET request with a querystring."
-    (let [creds (get-credentials)]
-      (-> (get! "https://www.mdsol.com" "/api/v2/testing?testABCD=1234")
-          (= mock-get-with-qs)
-          is)))
+    (let [creds (get-credentials)
+          get-response (get! "https://www.mdsol.com" "/api/v2/testing?testABCD=1234")]
+      (is (= mock-get-with-qs get-response))))
 
   (testing "It should make a valid POST request."
-    (let [creds (get-credentials)]
-      (-> (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload)
-          (= mock-post)
-          is)))
+    (let [creds (get-credentials)
+          post-response (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload)]
+      (is (= mock-post post-response))))
 
   (testing "It should make a valid DELETE request."
-    (let [creds (get-credentials)]
-      (-> (delete! "https://www.mdsol.com" "/api/v2/testing2")
-          (= mock-delete)
-          is)))
+    (let [creds (get-credentials)
+          delete-response (delete! "https://www.mdsol.com" "/api/v2/testing2")]
+      (is (= mock-delete delete-response))))
 
   (testing "It should make a valid PUT request."
-    (let [creds (get-credentials)]
-      (-> (put! "https://www.mdsol.com" "/api/v2/testing3" mock-payload)
-          (= mock-put)
-          is)))
+    (let [creds (get-credentials)
+          put-response (put! "https://www.mdsol.com" "/api/v2/testing3" mock-payload)]
+      (is (= mock-put put-response))))
 
-   (testing "It should make a valid POST request with v2 mauth header"
-            (let [creds (get-credentials)]
-                 (-> (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
-                            :with-sni? false)
-                     (= mock-post-v2)
-                     is)))
+  (testing "It should make a valid POST request with v2 mauth header"
+    (let [creds (get-credentials)
+          post-response (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
+                               :with-sni? false)]
+      (is (= mock-post-v2 post-response))))
 
-   (testing "It should make a valid PUT request with v2 mauth header"
-           (let [creds (get-credentials)]
-                 (-> (put! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
-                            :with-sni? false)
-                     (= mock-put-v2)
-                     is)))
+  (testing "It should make a valid PUT request with v2 mauth header"
+    (let [creds (get-credentials)
+          put-response (put! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
+                             :with-sni? false)]
+      (is (= mock-put-v2 put-response))))
 
-   (testing "It should make a valid GET request with v2 mauth header"
-            (let [creds (get-credentials)]
-                 (-> (get! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
-                           :with-sni? false)
-                     (= mock-get-v2)
-                     is)))
+  (testing "It should make a valid GET request with v2 mauth header"
+    (let [creds (get-credentials)
+          get-response (get! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
+                             :with-sni? false)]
+      (is (= mock-get-v2 get-response))))
 
-   (testing "It should make a valid GET request with query string and with v2 mauth header"
+  (testing "It should make a valid GET request with query string and with v2 mauth header"
 
-            (let [creds (get-credentials)]
-                 (-> (get! "https://www.mdsol.com" "/api/v2/testing1?testABCD=1234" :additional-headers additional-headers
-                           :with-sni? false)
-                     (= mock-get-with-qs-v2)
-                     is)))
+    (let [creds (get-credentials)
+          get-response (get! "https://www.mdsol.com" "/api/v2/testing1?testABCD=1234" :additional-headers additional-headers
+                             :with-sni? false)]
+      (is (= mock-get-with-qs-v2 get-response))))
 
-   (testing "It should make a valid DELETE request with v2 mauth header"
-            (let [creds (get-credentials)]
-                 (-> (delete! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
-                           :with-sni? false)
-                     (= mock-delete-v2)
-                     is)))
-  )
+  (testing "It should make a valid DELETE request with v2 mauth header"
+    (let [creds (get-credentials)
+          delete-response (delete! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
+                                   :with-sni? false)]
+      (is (= mock-delete-v2) delete-response))))

--- a/test/clojure_mauth_client/request_test.clj
+++ b/test/clojure_mauth_client/request_test.clj
@@ -39,6 +39,7 @@
                         "https://mauth-sandbox.imedidata.net")
 
     (with-redefs [clojure-mauth-client.header/epoch-seconds (fn [] 1532825948)
+                  clojure-mauth-client.header-v2/epoch-seconds (fn [] 1532825948)
                   clj-http.client/request (fn [{:keys [client timeout filter worker-pool keepalive as follow-redirects max-redirects response
                                                        trace-redirects allow-unsafe-redirect-methods proxy-host proxy-port tunnel?]
                                                 :as   opts

--- a/test/clojure_mauth_client/request_test.clj
+++ b/test/clojure_mauth_client/request_test.clj
@@ -37,6 +37,7 @@
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
                         "https://mauth-sandbox.imedidata.net")
+
     (with-redefs [clojure-mauth-client.header/epoch-seconds (fn [] 1532825948)
                   clj-http.client/request (fn [{:keys [client timeout filter worker-pool keepalive as follow-redirects max-redirects response
                                                        trace-redirects allow-unsafe-redirect-methods proxy-host proxy-port tunnel?]
@@ -54,9 +55,7 @@
                                                        proxy-host       nil
                                                        proxy-port       3128}}
                                                & [callback]] opts)]
-      (f)
-      )
-    ))
+      (f))))
 
 (def mock-get
   {:headers          {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
@@ -65,8 +64,7 @@
    :method           :get,
    :body             "\"\"",
    :throw-exceptions false
-   :as               :auto}
-  )
+   :as               :auto})
 
 (def mock-get-with-qs
   {:headers          {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
@@ -75,8 +73,7 @@
    :method           :get,
    :body             "\"\"",
    :throw-exceptions false
-   :as               :auto}
-  )
+   :as               :auto})
 
 (def mock-post
   {:headers          {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:kYZR1udBwE02ct55cSWq5MZuGsC6xgVmK6TWYQ/+2IAbhqG7jZWhP95bPxTqo1f12XUWsX/oeUAp8jhvdUcsXsjVMeBwvQNgnC/HP1TNQasC2LMGfOs76WnsfKoV5zWDh+SNqMqn4pIXce3DALG9d/FB2Uu4mIg9kgQIUnfJJDljfLMjR7aMgDINPU7ToM51TqTJh+ReG7LAVwsEzSwFfj4zZFFpx8XrWn3inx5ZUvT7YcFhW4vOZaeI48HSnj80bCf1LDtWXzU7yk9gon+AlIYBTtrPQTSqyofBGZUtZCBexnoEp6NUhk5XkwqK56jizT7PZCN094kh1eofr3hSTg=="
@@ -85,8 +82,7 @@
    :method           :post
    :body             "\"{\\\"a\\\":{\\\"b\\\":123}}\""
    :throw-exceptions false
-   :as               :auto}
-  )
+   :as               :auto})
 
 (def mock-delete
   {:headers          {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:IzAzkGyzDtxbMlCbbWViYen/9o54B9Ijlnp1UoSIysGr/axJWwph8KRYukS+3DhYFJIBLbS1PfWI74kRTkWJl3Vmb0XgxiRfNCqresqh687ELlhNDt66p2mu/6LaVwbDKUBsIAwkQFomVfAOy3jckWZjHRySD+VABfDf4BAf5hfjTUgil63oOnH6xII51e6M160SFRz1/HpsMU/rnReniPJs22MwiqS6dhe3oU/DAzteawxujSdFA3i6Fol6kdJQN19w+0TTdOSbccjds1Wljqu/+E1ju1rXVAgcL0GuVg4dsCwrjSPY9VWfQOttpA4aHavGWNcPMh1p1kSmqlNa1g=="
@@ -182,41 +178,31 @@
     (let [creds (get-credentials)]
       (-> (get! "https://www.mdsol.com" "/api/v2/testing")
           (= mock-get)
-          is
-          )
-      ))
+          is)))
 
   (testing "It should make a valid GET request with a querystring."
     (let [creds (get-credentials)]
       (-> (get! "https://www.mdsol.com" "/api/v2/testing?testABCD=1234")
           (= mock-get-with-qs)
-          is
-          )
-      ))
+          is)))
 
   (testing "It should make a valid POST request."
     (let [creds (get-credentials)]
       (-> (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload)
           (= mock-post)
-          is
-          )
-      ))
+          is)))
 
   (testing "It should make a valid DELETE request."
     (let [creds (get-credentials)]
       (-> (delete! "https://www.mdsol.com" "/api/v2/testing2")
           (= mock-delete)
-          is
-          )
-      ))
+          is)))
 
   (testing "It should make a valid PUT request."
     (let [creds (get-credentials)]
       (-> (put! "https://www.mdsol.com" "/api/v2/testing3" mock-payload)
           (= mock-put)
-          is
-          )
-      ))
+          is)))
 
    (testing "It should make a valid POST request with v2 mauth header"
             (let [creds (get-credentials)]
@@ -245,8 +231,7 @@
                  (-> (get! "https://www.mdsol.com" "/api/v2/testing1?testABCD=1234" :additional-headers additional-headers
                            :with-sni? false)
                      (= mock-get-with-qs-v2)
-                     is
-                     )))
+                     is)))
 
    (testing "It should make a valid DELETE request with v2 mauth header"
             (let [creds (get-credentials)]

--- a/test/clojure_mauth_client/request_test.clj
+++ b/test/clojure_mauth_client/request_test.clj
@@ -106,6 +106,74 @@
    :throw-exceptions false
    :as               :auto})
 
+(def mock-post-v2
+  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfmLrKcQkr2KnO03jFGALsOXpPSAFWgsbP0TvfvwraW7nveyRqXgzDVSFM23kG2bku319Cm5OBtikQHLYZo6BRMZZ+iGvAGh3XEs6dlAlaFLvzvgGn+TFJqbQCbMoeb87UHEif4aLLLIQW3B4GuMFVzU3dqT1jrmte3GBhlEfoKiQiaXMRmEHI+y3rrg7uWSNXLEwmgzygHTRsGD4Mgt8QHd4sprY3M6In/kmPveztAKntFDDteb2YsTck0pyTgh3mi5r0sIEdHcsGhxeO+utgDt3vPUI8QcPvBICuy8BouXVWnDAv6HzQ26og==;"
+             "mcc-time"      "1532825948"
+             :Content-Type "application/json"
+             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+             :mauth-version "v2"
+             }
+   :url "https://www.mdsol.com/api/v2/testing1"
+   :method :post
+   :body "\"{\\\"a\\\":{\\\"b\\\":123}}\""
+   :throw-exceptions false
+   :as :auto})
+
+(def mock-put-v2
+  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:JxNEVDUfC2iV2dNZ+p9bbP/efQaDEYvp1Y6LY7svXE+S4uF1sfOBw296iO3/sDYNm/eQz6OY6o+A0ti4L9kBpQgRqbSq6Q673gLEYOMrCswqMCM0uxJ1g95RBADgZVIg0ssjoSBU8lo1OXxjwhxz17PnDN+KTqw10DT2aiecmbhvvMVj3zAxG0vb9xxkIqYEFFkBolLoevriCL5PLqR8o2H1LmJ4eVvnR0HFetZyFEJM9KNxcQ1H8xYM8bZiocjLwPbCBk2IP3MRmgoeosTSgcAVRw7+7QRIpigz4kfc5pxHTuIa6k8voHyVzpW5uBolUBu7O1CvSgPVn2q/y+qrTQ==;"
+             "mcc-time"      "1532825948"
+             :Content-Type "application/json"
+             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+             :mauth-version "v2"
+             }
+   :url "https://www.mdsol.com/api/v2/testing1"
+   :method :put
+   :body "\"{\\\"a\\\":{\\\"b\\\":123}}\""
+   :throw-exceptions false
+   :as :auto})
+
+(def mock-get-v2
+  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:VELmFCqhoonHjj53gW0u2k2Ot30TU21CrWuzvIIR6FscCUdLMIRdK63lS3sLizkGH/X3YdlTLu3i67/Iw0SqkD2WzbkDHk00OP2Vf9S5ZLjkrFbkQgd8m4Kf0b1qmepXpHs2rZOnKep2/CIIZCHbitDe07oaNyI0ta+pZ76FKjbdsLS3BEUm5tW12eTlQkibeGuPb0yyso516x7Ya82lva4cTlZkIv4VfnVOtZs72BoL89uQsP7VflkYTP3aHMBZN90h6jjxKfZhF/I5Uo1W42Ci9I6i8SSa3O7g3M4msILxQzreVV0VYLg0ee+Vslu1T7cvXxmy9ZlfMMxf3H6LUg==;"
+             "mcc-time" "1532825948"
+             :Content-Type "application/json"
+             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+             :mauth-version "v2"
+             }
+   :url "https://www.mdsol.com/api/v2/testing1"
+   :method :get
+   :body "\"\""
+   :throw-exceptions false
+   :as :auto})
+
+(def mock-get-with-qs-v2
+  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:VELmFCqhoonHjj53gW0u2k2Ot30TU21CrWuzvIIR6FscCUdLMIRdK63lS3sLizkGH/X3YdlTLu3i67/Iw0SqkD2WzbkDHk00OP2Vf9S5ZLjkrFbkQgd8m4Kf0b1qmepXpHs2rZOnKep2/CIIZCHbitDe07oaNyI0ta+pZ76FKjbdsLS3BEUm5tW12eTlQkibeGuPb0yyso516x7Ya82lva4cTlZkIv4VfnVOtZs72BoL89uQsP7VflkYTP3aHMBZN90h6jjxKfZhF/I5Uo1W42Ci9I6i8SSa3O7g3M4msILxQzreVV0VYLg0ee+Vslu1T7cvXxmy9ZlfMMxf3H6LUg==;"             "mcc-time" "1532825948"
+             :Content-Type "application/json"
+             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+             :mauth-version "v2"
+             }
+   :url "https://www.mdsol.com/api/v2/testing1?testABCD=1234"
+   :method :get
+   :body "\"\""
+   :throw-exceptions false
+   :as :auto})
+
+(def mock-delete-v2
+  {:headers {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:rQR2OK8w3ixCyVqMZCxzUcEObaigSLfoHSgiGbONc0MD7GrhZ3rLLefV3nUaf3g/0hQi3Irx07NU+yBNS37Orya8eufqwsod1P2FeutNbHVLFhjTG+D/+StknEemQfzV7ZZ3abejzc02QP2QWn9jUk9sQjhByPcVbxapwnM2JAj5hCKmm1hE5UsJBk6YW59gWpTUPGGkDlp39LZfTV0lDOc402STy5h56FZSd9I92LA78f6ojF2izYlmp6Q+12FjuWARn9bjBPewRk8cKhYUs3fVl4ZEFwMyQM759waX9VASE9e/UCiFZTbZL2tCrvIRFys5FYmTy53A1pYZGjJ7Kw==;"
+             "mcc-time" "1532825948"
+             :Content-Type "application/json"
+             :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+             :mauth-version "v2"
+             }
+   :url "https://www.mdsol.com/api/v2/testing1"
+   :method :delete
+   :body "\"\""
+   :throw-exceptions false
+   :as :auto})
+
+(def additional-headers {:Content-Type "application/json"
+                         :Authorization "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                         :mauth-version "v2"})
+
 (def mock-payload (-> {:a {:b 123}}
                       json/write-str))
 
@@ -149,4 +217,41 @@
           is
           )
       ))
+
+   (testing "It should make a valid POST request with v2 mauth header"
+            (let [creds (get-credentials)]
+                 (-> (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
+                            :with-sni? false)
+                     (= mock-post-v2)
+                     is)))
+
+   (testing "It should make a valid PUT request with v2 mauth header"
+           (let [creds (get-credentials)]
+                 (-> (put! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
+                            :with-sni? false)
+                     (= mock-put-v2)
+                     is)))
+
+   (testing "It should make a valid GET request with v2 mauth header"
+            (let [creds (get-credentials)]
+                 (-> (get! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
+                           :with-sni? false)
+                     (= mock-get-v2)
+                     is)))
+
+   (testing "It should make a valid GET request with query string and with v2 mauth header"
+
+            (let [creds (get-credentials)]
+                 (-> (get! "https://www.mdsol.com" "/api/v2/testing1?testABCD=1234" :additional-headers additional-headers
+                           :with-sni? false)
+                     (= mock-get-with-qs-v2)
+                     is
+                     )))
+
+   (testing "It should make a valid DELETE request with v2 mauth header"
+            (let [creds (get-credentials)]
+                 (-> (delete! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
+                           :with-sni? false)
+                     (= mock-delete-v2)
+                     is)))
   )


### PR DESCRIPTION
[MCC-1059946](https://jira.mdsol.com/browse/MCC-1059946)

Clojure-mouth-client does not have support for version 2 (Mauth V2) . As per discussion with "Platfprm Superheros"  this Mauth is not owned by anyone if we find any issue in it whoever using it has to resolve it or look for alternate solution. Here in SF we are using Clojure-Mauth -Client across all outside calls, so to keep this consistent we will need to make changes in Clojure-mauth-client to make it support version 2(V2).

## Checklist

- [ ] Review the pull request to fix typos and ensure variable/function names are intuitive, etc.
- [ ] Make sure you have added tests for the code changes.
- [ ] Modify docs, if required.
- [ ] If the pull request has UI changes, take screenshots of the UI changed.
- [ ] Rebase on latest active development branch (develop/master). 


### Changes Summary
1. request.clj file is updated to add support to add version to headers
2. header.clj file is updated to sign the request with version to algorithm and add header values as per version 2 format.
3. project.clj file is updated to bump the library version.
4. added test cases for respective file.