### PR TITLE
MCC-1135087 Changes to update Unauthorized response code to 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,16 @@ To do your calls with SNI, pass `:with-sni? true` to your calls.
 For example,
 `(mauth/get! "https://www.mdsol.com" "/api/v2/testing.json" :with-sni? true)`
 
-Version 2.0.1 update -
+Version 2.0.2 update -
 We have added support for mauth version 2 headers as well now. To get the v2 headers you need to add additional header in your request as
 "mauth-version" with value as "v2" and algorithm also uses query param if any to sign  or to generate these headers, so you will need to add additional header in your request as
 "query-param-string"  and value should be string of sorted and encoded query params e.g abc=abctest&test=testing%20value
 you will get the response version 2 headers as below-
 "mcc-authentication" authentication value
 "mcc-time"           mcc-time
+
+Version 2.0.3 update -
+Changed mauth unauthorized error status code from 403 to 401 code which corresponds to the right HTTP status code for Unauthorized.
 
 ## Contributing/ Tests
 Tests can be run using `lein test`.

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -24,7 +24,7 @@
       (if valid?
         (handler (-> request
                      (assoc :body serialized-body)))
-        {:status 403
+        {:status 401
          :body "Unauthorized."}
         )
       )

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -1,0 +1,33 @@
+(ns clojure-mauth-client.middleware-test
+  (:require [clojure-mauth-client.middleware :as middleware]
+            [clojure.test :refer [deftest testing is]]
+            [clojure-mauth-client.validate :refer [validate!]]))
+
+(def mock-post-request
+  {:headers        {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"
+                    "mcc-time"           "1532825948"
+                    :Content-Type        "application/json"
+                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                    :mauth-version       "v2"}
+   :url            "https://www.mdsol.com/api/v2/testing"
+   :request-method :post
+   :body           "\"{\"test\":{\"request\":123}}\""})
+
+(defn mock-handler [request]
+  {:body   "\"{\"test\":{\"response\":12345}}\""
+   :status 200})
+
+(deftest test-wrap-mauth-verification
+  (testing "Request should get validated successfully"
+           (with-redefs [validate!   (fn [& _] true)]
+             (let [f                     (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (f mock-post-request)]
+               (is (= 200 status))
+               (is (= "\"{\"test\":{\"response\":12345}}\"" body)))))
+
+  (testing "Request should get invalidated and should return Unauthorized with 401 error code"
+           (with-redefs [validate!   (fn [& _] false)]
+             (let [f                     (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (f mock-post-request)]
+               (is (= 401 status))
+               (is (= "Unauthorized." body))))))

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -19,7 +19,7 @@
 
 (deftest test-wrap-mauth-verification
   (testing "Request should get validated successfully"
-           (with-redefs [validate!   (fn [& _] true)]
+           (with-redefs [validate!   (fn [& _] (constantly true))]
              (let [f                     (middleware/wrap-mauth-verification mock-handler)
                    {:keys [status body]} (f mock-post-request)]
                (is (= 200 status))


### PR DESCRIPTION
[MCC-1135087](https://jira.mdsol.com/browse/MCC-1135087)

Without mauth headers the correct response from the API should be a 401, but is currently responding with a 403
So made changes to return it as 401.


Test case -Tested this with updating jar in it-admin app locally and checked status code. See below screenshot
<img width="1430" alt="Screenshot 2024-01-12 at 2 46 15 PM" src="https://github.com/mdsol/clojure-mauth-client/assets/123161312/022ec17e-4c2a-4527-9460-2fdb9ddc2661">
