### PR TITLE
MCC-1161451 changes to add validation for mauth v2 requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Leiningen/Boot Coords:
 
-```[clojure-mauth-client "2.0.1"]```
+```[clojure-mauth-client "2.0.4"]```
 
 Here it is folks, a nice, clean MAuth client done in the simplest and most minimal way possible, for your Clojure application.
 
@@ -79,6 +79,9 @@ you will get the response version 2 headers as below-
 Version 2.0.3 update -
 Changed mauth unauthorized error status code from 403 to 401 code which corresponds to the right HTTP status code for Unauthorized.
 And also changed signature algorithm to SHA512withRSA, previously it was SHA256withRSA.
+
+Version 2.0.4 update -
+With this version we have added support to validate mauth requests with v2 version and validating mcc-time and mcc-authentication headers.
 
 ## Contributing/ Tests
 Tests can be run using `lein test`.

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -4,11 +4,10 @@
   (:use clojure-mauth-client.validate))
 
 (defn- downcase-header-keys [headers]
-  (reduce
-   (fn [r [k v]]
-     (-> r
-         (merge {(-> (name k) lower-case) v})))
-   {} headers))
+  (reduce-kv
+    (fn [m k v]
+      (assoc m (lower-case (name k)) v))
+    {} headers))
 
 (defn wrap-mauth-verification [handler]
   (fn[request]

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -4,11 +4,10 @@
 
 (defn- downcase-header-keys [headers]
   (reduce
-    (fn[r [k v]]
-      (-> r
-          (merge {(-> (name k) lower-case) v}))
-      ) {} headers)
-  )
+   (fn [r [k v]]
+     (-> r
+         (merge {(-> (name k) lower-case) v})))
+   {} headers))
 
 (defn wrap-mauth-verification [handler]
   (fn[request]
@@ -29,8 +28,4 @@
         (handler (-> request
                      (assoc :body serialized-body)))
         {:status 401
-         :body "Unauthorized."}
-        )
-      )
-    )
-  )
+         :body "Unauthorized."}))))

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -20,7 +20,11 @@
                                 :else (slurp body))
           headers (-> (:headers request)
                       downcase-header-keys)
-          valid? (validate! (.toUpperCase (name method)) uri serialized-body (get headers "x-mws-time") (get headers "x-mws-authentication"))]
+          version (get headers "mauth-version")
+          [mauth-time mauth-auth mauth-version] (if (= version "v2")
+                                    [(get headers "mcc-time") (get headers "mcc-authentication") "v2"]
+                                    [(get headers "x-mws-time") (get headers "x-mws-authentication") "v1"])
+          valid?  (validate! (.toUpperCase (name method)) uri serialized-body mauth-time mauth-auth mauth-version)]
       (if valid?
         (handler (-> request
                      (assoc :body serialized-body)))

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -1,5 +1,6 @@
 (ns clojure-mauth-client.middleware
-  (:require [clojure.string :refer [lower-case]])
+  (:require [clojure.string :refer [lower-case]]
+            [clojure.data.json :as json])
   (:use clojure-mauth-client.validate))
 
 (defn- downcase-header-keys [headers]
@@ -16,6 +17,7 @@
            body :body} request
           serialized-body (cond (nil? body) ""
                                 (string? body) body
+                                (map? body) (json/write-str body)
                                 :else (slurp body))
           headers (-> (:headers request)
                       downcase-header-keys)

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -32,22 +32,22 @@
 (deftest test-wrap-mauth-verification
   (testing "Request should get validated successfully"
            (with-redefs [validate!   (fn [& _] (constantly true))]
-             (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request-v2)]
+             (let [request-function      (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (request-function mock-post-request-v2)]
                (is (= 200 status))
                (is (= "\"{\"test\":{\"response\":12345}}\"" body)))))
 
   (testing "Request should get invalidated and should return Unauthorized with 401 error code with v2"
            (with-redefs [validate!   (fn [& _] false)]
-             (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request-v2)]
+             (let [request-function      (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (request-function mock-post-request-v2)]
                (is (= 401 status))
                (is (= "Unauthorized." body)))))
 
   (testing "Request should get invalidated and should return Unauthorized with 401 error code with v1"
            (with-redefs [validate!   (fn [& _] false)]
-             (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request-v1)]
+             (let [request-function      (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (request-function mock-post-request-v1)]
                (is (= 401 status))
                (is (= "Unauthorized." body)))))
 
@@ -55,14 +55,14 @@
            (with-redefs  [post! (fn [& args]
                                   {:status 204})
                           get-credentials (constantly {:mauth-service-url "http://test.com"})]
-             (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request-v2)]
+             (let [request-function      (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (request-function mock-post-request-v2)]
                (is (= 200 status)))))
 
   (testing "Request should get validated as per v1 version"
            (with-redefs  [post! (fn [& args]
                                   {:status 204})
                           get-credentials (constantly {:mauth-service-url "http://test.com"})]
-             (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request-v1)]
+             (let [request-function      (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (request-function mock-post-request-v1)]
                (is (= 200 status))))))

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -1,15 +1,27 @@
 (ns clojure-mauth-client.middleware-test
   (:require [clojure-mauth-client.middleware :as middleware]
             [clojure.test :refer [deftest testing is]]
-            [clojure-mauth-client.validate :refer [validate!]]))
+            [clojure-mauth-client.validate :refer [validate!]]
+            [clojure-mauth-client.request :refer [post!]]
+            [clojure-mauth-client.credentials :refer [get-credentials]]))
 
-(def mock-post-request
+(def mock-post-request-v2
   {:headers        {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"
                     "mcc-time"           "1532825948"
                     :Content-Type        "application/json"
                     :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
                     :mauth-version       "v2"}
    :url            "https://www.mdsol.com/api/v2/testing"
+   :request-method :post
+   :body           "\"{\"test\":{\"request\":123}}\""})
+
+(def mock-post-request-v1
+  {:headers        {"x-mws-authentication" "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
+                    "x-mws-time"           "1532825948"
+                    :Content-Type        "application/json"
+                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
+                    :mauth-version       "v1"}
+   :url            "https://www.mdsol.com/api/v1/testing"
    :request-method :post
    :body           "\"{\"test\":{\"request\":123}}\""})
 
@@ -21,13 +33,36 @@
   (testing "Request should get validated successfully"
            (with-redefs [validate!   (fn [& _] (constantly true))]
              (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request)]
+                   {:keys [status body]} (f mock-post-request-v2)]
                (is (= 200 status))
                (is (= "\"{\"test\":{\"response\":12345}}\"" body)))))
 
-  (testing "Request should get invalidated and should return Unauthorized with 401 error code"
+  (testing "Request should get invalidated and should return Unauthorized with 401 error code with v2"
            (with-redefs [validate!   (fn [& _] false)]
              (let [f                     (middleware/wrap-mauth-verification mock-handler)
-                   {:keys [status body]} (f mock-post-request)]
+                   {:keys [status body]} (f mock-post-request-v2)]
                (is (= 401 status))
-               (is (= "Unauthorized." body))))))
+               (is (= "Unauthorized." body)))))
+
+  (testing "Request should get invalidated and should return Unauthorized with 401 error code with v1"
+           (with-redefs [validate!   (fn [& _] false)]
+             (let [f                     (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (f mock-post-request-v1)]
+               (is (= 401 status))
+               (is (= "Unauthorized." body)))))
+
+  (testing "Request should get validated as per v2 version"
+           (with-redefs  [post! (fn [& args]
+                                  {:status 204})
+                          get-credentials (constantly {:mauth-service-url "http://test.com"})]
+             (let [f                     (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (f mock-post-request-v2)]
+               (is (= 200 status)))))
+
+  (testing "Request should get validated as per v1 version"
+           (with-redefs  [post! (fn [& args]
+                                  {:status 204})
+                          get-credentials (constantly {:mauth-service-url "http://test.com"})]
+             (let [f                     (middleware/wrap-mauth-verification mock-handler)
+                   {:keys [status body]} (f mock-post-request-v1)]
+               (is (= 200 status))))))

--- a/test/clojure_mauth_client/validate_test.clj
+++ b/test/clojure_mauth_client/validate_test.clj
@@ -1,0 +1,39 @@
+(ns clojure-mauth-client.validate-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure-mauth-client.validate :refer [validate!]]
+            [clojure-mauth-client.request :refer [post!]]
+            [clojure-mauth-client.credentials :refer [get-credentials]]))
+
+(defn- request-data []
+  {:verb         (.toUpperCase (name :post))
+   :url          "https://www.mdsol.com/api/v1/testing"
+   :body         "\"{\"test\":{\"request\":123}}\""
+   :time         "1532825948"
+   :v1-signature "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
+   :v2-signature "MWSV2 a5a733c5-2bae-400c-aae9-6bb5b99d4130:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"})
+
+(deftest test-validate-success
+  (with-redefs [post!           (fn [& args]
+                                  {:status 204})
+                get-credentials (constantly {:mauth-service-url "http://test.com"})]
+
+    (testing "testing validate with mauth v1 version"
+             (let [{:keys [verb url body time v1-signature]} (request-data)]
+               (is (= true (validate! verb url body time v1-signature)))))
+
+    (testing "testing validate with mauth v2 version"
+             (let [{:keys [verb url body time v2-signature]} (request-data)]
+               (is (= true (validate! verb url body time v2-signature "v2")))))))
+
+(deftest test-validate-failure
+  (with-redefs [post!           (fn [& args]
+                                  {:status 400})
+                get-credentials (constantly {:mauth-service-url "http://test.com"})]
+
+    (testing "testing validate with mauth v1 version"
+             (let [{:keys [verb url body time v1-signature]} (request-data)]
+               (is (= false (validate! verb url body time v1-signature)))))
+
+    (testing "testing validate with mauth v2 version"
+             (let [{:keys [verb url body time v2-signature]} (request-data)]
+               (is (= false (validate! verb url body time v2-signature "v2")))))))

--- a/test/clojure_mauth_client/validate_test.clj
+++ b/test/clojure_mauth_client/validate_test.clj
@@ -19,11 +19,11 @@
 
     (testing "testing validate with mauth v1 version"
              (let [{:keys [verb url body time v1-signature]} (request-data)]
-               (is (= true (validate! verb url body time v1-signature)))))
+               (is (true? (validate! verb url body time v1-signature)))))
 
     (testing "testing validate with mauth v2 version"
              (let [{:keys [verb url body time v2-signature]} (request-data)]
-               (is (= true (validate! verb url body time v2-signature "v2")))))))
+               (is (true? (validate! verb url body time v2-signature "v2")))))))
 
 (deftest test-validate-failure
   (with-redefs [post!           (fn [& args]
@@ -32,8 +32,8 @@
 
     (testing "testing validate with mauth v1 version"
              (let [{:keys [verb url body time v1-signature]} (request-data)]
-               (is (= false (validate! verb url body time v1-signature)))))
+               (is (false? (validate! verb url body time v1-signature)))))
 
     (testing "testing validate with mauth v2 version"
              (let [{:keys [verb url body time v2-signature]} (request-data)]
-               (is (= false (validate! verb url body time v2-signature "v2")))))))
+               (is (false? (validate! verb url body time v2-signature "v2")))))))


### PR DESCRIPTION
[MCC-1161451](https://jira.mdsol.com/browse/MCC-1161451)
Currently clojure-mauth-client is not validating version 2 mcc-time and mcc-authentication , its only validating v1 .
Need to add validation for v2 headers mcc-time and mcc-authentication, so made necessary changes.