### PR TITLE
MCC-1180480 Changes to remove dependency of mauth-header for v2 reque…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Leiningen/Boot Coords:
 
-```[clojure-mauth-client "2.0.4"]```
+```[clojure-mauth-client "2.0.5"]```
 
 Here it is folks, a nice, clean MAuth client done in the simplest and most minimal way possible, for your Clojure application.
 
@@ -82,6 +82,10 @@ And also changed signature algorithm to SHA512withRSA, previously it was SHA256w
 
 Version 2.0.4 update -
 With this version we have added support to validate mauth requests with v2 version and validating mcc-time and mcc-authentication headers.
+
+Version 2.0.5 update -
+With this version we have removed dependency of extra header "mauth-version" that we needed to validate mauth requests with v2 version. 
+No need to send this extra header to validate v2 version requests.
 
 ## Contributing/ Tests
 Tests can be run using `lein test`.

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -20,10 +20,9 @@
                                 :else (slurp body))
           headers (-> (:headers request)
                       downcase-header-keys)
-          version (get headers "mauth-version")
-          [mauth-time mauth-auth mauth-version] (if (= version "v2")
-                                    [(get headers "mcc-time") (get headers "mcc-authentication") "v2"]
-                                    [(get headers "x-mws-time") (get headers "x-mws-authentication") "v1"])
+          [mauth-time mauth-auth mauth-version] (if (every? headers ["mcc-time" "mcc-authentication"])
+                                                  [(get headers "mcc-time") (get headers "mcc-authentication") "v2"]
+                                                  [(get headers "x-mws-time") (get headers "x-mws-authentication") "v1"])
           valid?  (validate! (.toUpperCase (name method)) uri serialized-body mauth-time mauth-auth mauth-version)]
       (if valid?
         (handler (-> request

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -20,20 +20,25 @@
                                 :else (slurp body))
           headers (-> (:headers request)
                       downcase-header-keys)
-          [mauth-time mauth-auth mauth-version] (cond
+          [mauth-time mauth-auth] (cond
                                                   (every? headers
                                                           ["mcc-time"
                                                            "mcc-authentication"])     [(get headers "mcc-time")
-                                                                                       (get headers "mcc-authentication")
-                                                                                       "v2"]
+                                                                                       (get headers "mcc-authentication")]
                                                   (every? headers
                                                           ["x-mws-time"
                                                            "x-mws-authentication"])   [(get headers "x-mws-time")
-                                                                                       (get headers "x-mws-authentication")
-                                                                                       "v1"]
+                                                                                       (get headers "x-mws-authentication")]
                                                   :else                               (throw
                                                                                         (ex-info "No Mauth headers found"
                                                                                                  {:header-names (sort (keys headers))})))
+          mauth-version (let [signature (signature-map mauth-auth)
+                              token     (:token signature)]
+                          (cond
+                            (= token "MWSV2")                   "v2"
+                            (= token "MWS")                     "v1"
+                            :else                               (throw
+                                                                  (ex-info "Mauth signature is not valid" {:signature mauth-auth}))))
           valid?  (validate! (.toUpperCase (name method)) uri serialized-body mauth-time mauth-auth mauth-version)]
       (if valid?
         (handler (-> request

--- a/src/clojure_mauth_client/validate.clj
+++ b/src/clojure_mauth_client/validate.clj
@@ -30,7 +30,11 @@
          sig              (signature-map signature)
          auth-body        (build-auth-ticket-body verb (:app-uuid sig) uri body time (:signature sig))
          updated-body     (if (= mauth-version "v2")
-                            (assoc-in auth-body [:authentication_ticket :token] (:token sig))
+                            (if (= (:token sig) "MWSV2")
+                              (assoc-in auth-body [:authentication_ticket :token] (:token sig))
+                              (throw
+                                (ex-info "Invalid token found in v2 signature,it should be MWSV2"
+                                         {:token (:token sig)})))
                             auth-body)
          auth-ticket-body (json/write-str updated-body)]
      (->

--- a/src/clojure_mauth_client/validate.clj
+++ b/src/clojure_mauth_client/validate.clj
@@ -16,7 +16,7 @@
         :request_time time
         :client_signature signature}})
 
-(defn- signature-map [msg]
+(defn signature-map [msg]
   (let [signature msg
         values-fn (fn [s] (rest (re-find #"\A(\S+)\s*([^:]+):([^:]+)\z" s)))]
     (if (nil? signature) {}
@@ -30,11 +30,7 @@
          sig              (signature-map signature)
          auth-body        (build-auth-ticket-body verb (:app-uuid sig) uri body time (:signature sig))
          updated-body     (if (= mauth-version "v2")
-                            (if (= (:token sig) "MWSV2")
-                              (assoc-in auth-body [:authentication_ticket :token] (:token sig))
-                              (throw
-                                (ex-info "Invalid token found in v2 signature,it should be MWSV2"
-                                         {:token (:token sig)})))
+                            (assoc-in auth-body [:authentication_ticket :token] (:token sig))
                             auth-body)
          auth-ticket-body (json/write-str updated-body)]
      (->

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -30,6 +30,15 @@
    :request-method :post
    :body           "\"{\"test\":{\"request\":123}}\""})
 
+(def mock-post-request-v2-with-invalid-signature
+  {:headers        {"mcc-authentication" "MWSV abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"
+                    "mcc-time"           "1532825948"
+                    :Content-Type        "application/json"
+                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"}
+   :url            "https://www.mdsol.com/api/v2/testing"
+   :request-method :post
+   :body           "\"{\"test\":{\"request\":123}}\""})
+
 (defn mock-handler [{:keys [body] :as request}]
   {:body   body
    :status 200})
@@ -75,4 +84,9 @@
   (testing "Exception should be thrown with message as no auth headers sent"
            (let [request-function      (middleware/wrap-mauth-verification mock-handler)]
              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No Mauth headers found"
-                        (request-function mock-post-request-without-mauth-headers))))))
+                        (request-function mock-post-request-without-mauth-headers)))))
+
+  (testing "Exception should be thrown with message as Mauth signature is not valid"
+           (let [request-function      (middleware/wrap-mauth-verification mock-handler)]
+             (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Mauth signature is not valid"
+                                   (request-function mock-post-request-v2-with-invalid-signature))))))

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -23,6 +23,13 @@
    :request-method :post
    :body           "\"{\"test\":{\"request\":123}}\""})
 
+(def mock-post-request-without-mauth-headers
+  {:headers        {:Content-Type        "application/json"
+                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"}
+   :url            "https://www.mdsol.com/api/v1/testing"
+   :request-method :post
+   :body           "\"{\"test\":{\"request\":123}}\""})
+
 (defn mock-handler [{:keys [body] :as request}]
   {:body   body
    :status 200})
@@ -63,4 +70,9 @@
                           get-credentials (constantly {:mauth-service-url "http://test.com"})]
              (let [request-function      (middleware/wrap-mauth-verification mock-handler)
                    {:keys [status body]} (request-function mock-post-request-v1)]
-               (is (= 200 status))))))
+               (is (= 200 status)))))
+
+  (testing "Exception should be thrown with message as no auth headers sent"
+           (let [request-function      (middleware/wrap-mauth-verification mock-handler)]
+             (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No Mauth headers found"
+                        (request-function mock-post-request-without-mauth-headers))))))

--- a/test/clojure_mauth_client/middleware_test.clj
+++ b/test/clojure_mauth_client/middleware_test.clj
@@ -9,8 +9,7 @@
   {:headers        {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"
                     "mcc-time"           "1532825948"
                     :Content-Type        "application/json"
-                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                    :mauth-version       "v2"}
+                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"}
    :url            "https://www.mdsol.com/api/v2/testing"
    :request-method :post
    :body           "\"{\"test\":{\"request\":123}}\""})
@@ -19,14 +18,13 @@
   {:headers        {"x-mws-authentication" "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
                     "x-mws-time"           "1532825948"
                     :Content-Type        "application/json"
-                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                    :mauth-version       "v1"}
+                    :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"}
    :url            "https://www.mdsol.com/api/v1/testing"
    :request-method :post
    :body           "\"{\"test\":{\"request\":123}}\""})
 
-(defn mock-handler [request]
-  {:body   "\"{\"test\":{\"response\":12345}}\""
+(defn mock-handler [{:keys [body] :as request}]
+  {:body   body
    :status 200})
 
 (deftest test-wrap-mauth-verification
@@ -35,7 +33,7 @@
              (let [request-function      (middleware/wrap-mauth-verification mock-handler)
                    {:keys [status body]} (request-function mock-post-request-v2)]
                (is (= 200 status))
-               (is (= "\"{\"test\":{\"response\":12345}}\"" body)))))
+               (is (= "\"{\"test\":{\"request\":123}}\"" body)))))
 
   (testing "Request should get invalidated and should return Unauthorized with 401 error code with v2"
            (with-redefs [validate!   (fn [& _] false)]

--- a/test/clojure_mauth_client/validate_test.clj
+++ b/test/clojure_mauth_client/validate_test.clj
@@ -44,9 +44,4 @@
 
     (testing "testing validate with mauth v2 version"
              (let [{:keys [verb url body time v2-signature]} (request-data)]
-               (is (false? (validate! verb url body time v2-signature "v2")))))
-
-    (testing "testing validate with mauth v2 version but invalid token"
-             (let [{:keys [verb url body time v2-signature]} (request-data-with-invalid-token)]
-               (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid token found in v2 signature,it should be MWSV2"
-                                     (validate! verb url body time v2-signature "v2")))))))
+               (is (false? (validate! verb url body time v2-signature "v2")))))))

--- a/test/clojure_mauth_client/validate_test.clj
+++ b/test/clojure_mauth_client/validate_test.clj
@@ -12,6 +12,14 @@
    :v1-signature "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
    :v2-signature "MWSV2 a5a733c5-2bae-400c-aae9-6bb5b99d4130:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"})
 
+(defn- request-data-with-invalid-token []
+  {:verb         (.toUpperCase (name :post))
+   :url          "https://www.mdsol.com/api/v1/testing"
+   :body         "\"{\"test\":{\"request\":123}}\""
+   :time         "1532825948"
+   :v1-signature "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
+   :v2-signature "MWSV a5a733c5-2bae-400c-aae9-6bb5b99d4130:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"})
+
 (deftest test-validate-success
   (with-redefs [post!           (fn [& args]
                                   {:status 204})
@@ -36,4 +44,9 @@
 
     (testing "testing validate with mauth v2 version"
              (let [{:keys [verb url body time v2-signature]} (request-data)]
-               (is (false? (validate! verb url body time v2-signature "v2")))))))
+               (is (false? (validate! verb url body time v2-signature "v2")))))
+
+    (testing "testing validate with mauth v2 version but invalid token"
+             (let [{:keys [verb url body time v2-signature]} (request-data-with-invalid-token)]
+               (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid token found in v2 signature,it should be MWSV2"
+                                     (validate! verb url body time v2-signature "v2")))))))

--- a/test/clojure_mauth_client/validate_test.clj
+++ b/test/clojure_mauth_client/validate_test.clj
@@ -12,14 +12,6 @@
    :v1-signature "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
    :v2-signature "MWSV2 a5a733c5-2bae-400c-aae9-6bb5b99d4130:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"})
 
-(defn- request-data-with-invalid-token []
-  {:verb         (.toUpperCase (name :post))
-   :url          "https://www.mdsol.com/api/v1/testing"
-   :body         "\"{\"test\":{\"request\":123}}\""
-   :time         "1532825948"
-   :v1-signature "MWS a5a733c5-2bae-400c-aae9-6bb5b99d4130:SpjzqMFJ0cl8Lvi72TcU1qfVP9rzRWH/Jys2g==;"
-   :v2-signature "MWSV a5a733c5-2bae-400c-aae9-6bb5b99d4130:T0XZu8X6bUcKBW/QgX0RnUg0hfbcDfm==;"})
-
 (deftest test-validate-success
   (with-redefs [post!           (fn [& args]
                                   {:status 204})


### PR DESCRIPTION

[MCC-1180480](https://jira.mdsol.com/browse/MCC-1180480)
Currently in clojure-mauth-client we need to pass extra header mauth-version as v2 to authenticate request of v2 type , instead of this extra header we can verify mcc-time and mcc-authentication headers 

Change summary -
Removed dependancy of extra header "mauth-version" to validate v2 requests.
