### PR TITLE
Validate when query-string is present in the request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ pom.xml.asc
 .hg/
 *.iml
 .idea/
+tests.edn
+/.lsp/.cache
+/.clj-kondo/.cache
+/secrets/
+.vscode/
+/.calva

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ With this version we have removed throwing exceptions when not valid mauth heade
 Version 2.0.7 update-
 Updated few of the library versions to remove vulnerability
 
+Version 2.0.8 update -
+For mAuth Protocol V2, includes the query-string (when present), in the authentication ticket to validate the requests.
+
 ## Contributing/ Tests
 Tests can be run using `lein test`.
 

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/mdsol/clojure-mauth-client"
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.11.3"]
+  :dependencies [[org.clojure/clojure "1.12.0"]
                  [xsc/pem-reader "0.1.1"]
                  [digest "1.4.10"]
                  [org.clojure/data.codec "0.1.1"]

--- a/src/clojure_mauth_client/middleware.clj
+++ b/src/clojure_mauth_client/middleware.clj
@@ -13,7 +13,8 @@
   (fn[request]
     (let [{method :request-method
            uri :uri
-           body :body} request
+           body :body
+           query-string :query-string} request
           serialized-body (cond (nil? body) ""
                                 (string? body) body
                                 (map? body) (json/write-str body)
@@ -34,7 +35,7 @@
                           (cond
                             (= token "MWSV2")                   "v2"
                             (= token "MWS")                     "v1"))
-          valid?  (validate! (.toUpperCase (name method)) uri serialized-body mauth-time mauth-auth mauth-version)]
+          valid?  (validate! (.toUpperCase (name method)) uri serialized-body mauth-time mauth-auth mauth-version query-string)] 
       (if valid?
         (handler (-> request
                      (assoc :body serialized-body)))

--- a/src/clojure_mauth_client/validate.clj
+++ b/src/clojure_mauth_client/validate.clj
@@ -21,26 +21,26 @@
   (let [signature msg
         values-fn (fn [s] (rest (re-find #"\A(\S+)\s*([^:]+):([^:]+)\z" s)))]
     (if (nil? signature) {}
-      (zipmap [:token :app-uuid :signature] (values-fn (trim signature))))))
+        (zipmap [:token :app-uuid :signature] (values-fn (trim signature))))))
 
 (defn validate!
   ([verb uri body time signature]
    (validate! verb uri body time signature nil))
   ([verb uri body time signature mauth-version]
    (validate! verb uri body time signature mauth-version nil))
-  ( [verb uri body time signature mauth-version query-string]
+  ([verb uri body time signature mauth-version query-string]
    (prn :uri uri)
-    (let [creds            (get-credentials)
-          sig              (signature-map signature)
-          auth-body        (build-auth-ticket-body verb (:app-uuid sig) uri body time (:signature sig))
-          updated-body     (cond-> auth-body 
-                             (= mauth-version "v2") (assoc-in [:authentication_ticket :token] (:token sig))
-                             (and (= mauth-version "v2") query-string) (assoc-in [:authentication_ticket :query_string] query-string))
-          auth-ticket-body (json/write-str updated-body)]
-      (->
-       (post! (:mauth-service-url creds)
-              auth-uri
-              auth-ticket-body
-              :additional-headers {"Content-Type" "application/json"})
-       :status
-       (= 204)))))
+   (let [creds            (get-credentials)
+         sig              (signature-map signature)
+         auth-body        (build-auth-ticket-body verb (:app-uuid sig) uri body time (:signature sig))
+         updated-body     (cond-> auth-body
+                            (= mauth-version "v2") (assoc-in [:authentication_ticket :token] (:token sig))
+                            (and (= mauth-version "v2") query-string) (assoc-in [:authentication_ticket :query_string] query-string))
+         auth-ticket-body (json/write-str updated-body)]
+     (->
+      (post! (:mauth-service-url creds)
+             auth-uri
+             auth-ticket-body
+             :additional-headers {"Content-Type" "application/json"})
+      :status
+      (= 204)))))

--- a/src/clojure_mauth_client/validate.clj
+++ b/src/clojure_mauth_client/validate.clj
@@ -7,14 +7,15 @@
 
 (def ^{:private true} auth-uri "/mauth/v1/authentication_tickets.json")
 
-(defn- build-auth-ticket-body [verb app-uuid request-url body time signature]
+(defn- build-auth-ticket-body
+  [verb app-uuid request-url body time signature]
   {:authentication_ticket
-       {:app_uuid app-uuid
-        :verb verb
-        :request_url request-url
-        :b64encoded_body (String. (encode (.getBytes body)))
-        :request_time time
-        :client_signature signature}})
+   {:app_uuid app-uuid
+    :verb verb
+    :request_url request-url
+    :b64encoded_body (String. (encode (.getBytes body)))
+    :request_time time
+    :client_signature signature}})
 
 (defn signature-map [msg]
   (let [signature msg
@@ -26,14 +27,17 @@
   ([verb uri body time signature]
    (validate! verb uri body time signature nil))
   ([verb uri body time signature mauth-version]
-   (let [creds            (get-credentials)
-         sig              (signature-map signature)
-         auth-body        (build-auth-ticket-body verb (:app-uuid sig) uri body time (:signature sig))
-         updated-body     (if (= mauth-version "v2")
-                            (assoc-in auth-body [:authentication_ticket :token] (:token sig))
-                            auth-body)
-         auth-ticket-body (json/write-str updated-body)]
-     (->
+   (validate! verb uri body time signature mauth-version nil))
+  ( [verb uri body time signature mauth-version query-string]
+   (prn :uri uri)
+    (let [creds            (get-credentials)
+          sig              (signature-map signature)
+          auth-body        (build-auth-ticket-body verb (:app-uuid sig) uri body time (:signature sig))
+          updated-body     (cond-> auth-body 
+                             (= mauth-version "v2") (assoc-in [:authentication_ticket :token] (:token sig))
+                             (and (= mauth-version "v2") query-string) (assoc-in [:authentication_ticket :query_string] query-string))
+          auth-ticket-body (json/write-str updated-body)]
+      (->
        (post! (:mauth-service-url creds)
               auth-uri
               auth-ticket-body

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -9,7 +9,7 @@
   (fn [f]
     ;Note: these are NOT valid real credentials.
     (credentials/define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
-                        "-----BEGIN RSA PRIVATE KEY-----
+      "-----BEGIN RSA PRIVATE KEY-----
                         MIIEowIBAAKCAQEAsaa4gcNl4jx9YF7Y/6B+v29c0KBs1vxym0p4hwjZl5GteQgR
                         uFW5wM93F2lUFiVEQoM+Ti3AQjEDWdeuOIfo66LgbNLH7B3JhbkwHti/bMsq7T66
                         Gs3cOhMcKDrTswOv8x72QzsOf1FNs7Yzsu1iwJpttNg+VCRj169hQ/YI39KSuYzQ
@@ -36,7 +36,7 @@
                         9aWuKH+/XjdHf/J1n/AQ1j/G/WExs3UNfrvDgYea5QDnvc2gMBDRkdBwFZHYZLIn
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
-                        "https://mauth-sandbox.imedidata.net")
+      "https://mauth-sandbox.imedidata.net")
     (with-redefs [util/epoch-seconds (fn [] 1532825948)]
       (f))))
 

--- a/test/clojure_mauth_client/header_test.clj
+++ b/test/clojure_mauth_client/header_test.clj
@@ -45,7 +45,7 @@
     (let [creds (credentials/get-credentials)
           mauth-headers (header/build-mauth-headers "GET" "https://www.mdsol.com/api/v2/testing" "" (:app-uuid creds) (:private-key creds))]
       (is (= {"X-MWS-Authentication" "MWS abcd7d78-c874-47d9-a829-ccaa51ae75c9:gI/yUeSTbiOWggLvCv2IJP19GFvmlE8RoaUrIpyLE8DY/mCQd8CUPgT9xNHGNqgPGe9f4CZdiFCC79Xvp6seZAq8/CnqA1dsJW6f46scqqTs+4N1TJml6GNCT9xU4tjUyHWFWpCBQlSvpoTFsLSq2d2zas9M9q1sgwPBS/oPGEN1agCQLHZS/Ime4ub8MuXh0Q8aWodqCpVi4GPiap/KLIQEzbvhsdayxmAcs2XDjpt+CReRf3tBCzB1RucVEfBehxtDQGgvrs/UCUbkpq7gY7f2k0RkrH+IopfhYfdNpmCHW12OEQoZ74TVbh61Uo+xcD1der46+tWk0mdnlyXKow=="
-              "X-MWS-Time"           "1532825948"}))))
+              "X-MWS-Time"           "1532825948"} mauth-headers))))
 
   (testing "It should generate a valid mauth X-MWS header for response"
     (let [creds (credentials/get-credentials)

--- a/test/clojure_mauth_client/header_v2_test.clj
+++ b/test/clojure_mauth_client/header_v2_test.clj
@@ -9,7 +9,7 @@
   (fn [f]
     ;Note: these are NOT valid real credentials.
     (credentials/define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
-                        "-----BEGIN RSA PRIVATE KEY-----
+      "-----BEGIN RSA PRIVATE KEY-----
                         MIIEowIBAAKCAQEAsaa4gcNl4jx9YF7Y/6B+v29c0KBs1vxym0p4hwjZl5GteQgR
                         uFW5wM93F2lUFiVEQoM+Ti3AQjEDWdeuOIfo66LgbNLH7B3JhbkwHti/bMsq7T66
                         Gs3cOhMcKDrTswOv8x72QzsOf1FNs7Yzsu1iwJpttNg+VCRj169hQ/YI39KSuYzQ
@@ -36,10 +36,9 @@
                         9aWuKH+/XjdHf/J1n/AQ1j/G/WExs3UNfrvDgYea5QDnvc2gMBDRkdBwFZHYZLIn
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
-                        "https://mauth-sandbox.imedidata.net")
+      "https://mauth-sandbox.imedidata.net")
     (with-redefs [util/epoch-seconds (fn [] 1532825948)]
       (f))))
-
 
 (deftest header-v2-test
   (testing "It should generate a valid mauth MWSV2 header for POST"

--- a/test/clojure_mauth_client/request_test.clj
+++ b/test/clojure_mauth_client/request_test.clj
@@ -10,7 +10,7 @@
   (fn [f]
     ;Note: these are NOT valid real credentials.
     (define-credentials "abcd7d78-c874-47d9-a829-ccaa51ae75c9"
-                        "-----BEGIN RSA PRIVATE KEY-----
+      "-----BEGIN RSA PRIVATE KEY-----
                         MIIEowIBAAKCAQEAsaa4gcNl4jx9YF7Y/6B+v29c0KBs1vxym0p4hwjZl5GteQgR
                         uFW5wM93F2lUFiVEQoM+Ti3AQjEDWdeuOIfo66LgbNLH7B3JhbkwHti/bMsq7T66
                         Gs3cOhMcKDrTswOv8x72QzsOf1FNs7Yzsu1iwJpttNg+VCRj169hQ/YI39KSuYzQ
@@ -37,7 +37,7 @@
                         9aWuKH+/XjdHf/J1n/AQ1j/G/WExs3UNfrvDgYea5QDnvc2gMBDRkdBwFZHYZLIn
                         e+viqMbgmORJDP/8vbpd0yZjT25ImysJE5cSCGiqHOotDs3jdlUX
                         -----END RSA PRIVATE KEY-----"
-                        "https://mauth-sandbox.imedidata.net")
+      "https://mauth-sandbox.imedidata.net")
 
     (with-redefs [util/epoch-seconds (fn [] 1532825948)
                   clj-http.client/request (fn [{:keys [client timeout filter worker-pool keepalive as follow-redirects max-redirects response
@@ -108,8 +108,7 @@
                       "mcc-time"           "1532825948"
                       :Content-Type        "application/json"
                       :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                      :mauth-version       "v2"
-                      }
+                      :mauth-version       "v2"}
    :url              "https://www.mdsol.com/api/v2/testing1"
    :method           :post
    :body             "\"{\\\"a\\\":{\\\"b\\\":123}}\""
@@ -121,8 +120,7 @@
                       "mcc-time"           "1532825948"
                       :Content-Type        "application/json"
                       :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                      :mauth-version       "v2"
-                      }
+                      :mauth-version       "v2"}
    :url              "https://www.mdsol.com/api/v2/testing1"
    :method           :put
    :body             "\"{\\\"a\\\":{\\\"b\\\":123}}\""
@@ -134,8 +132,7 @@
                       "mcc-time"           "1532825948"
                       :Content-Type        "application/json"
                       :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                      :mauth-version       "v2"
-                      }
+                      :mauth-version       "v2"}
    :url              "https://www.mdsol.com/api/v2/testing1"
    :method           :get
    :body             "\"\""
@@ -146,8 +143,7 @@
   {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:fdWPNlo6rTdMKxw5wf0KpQMKm22Zuf6PIUQRwIYtyzZgNEgJjgjlVdQogSYHTBVuLMx1iuyXH9m/Mex0jzD0DFZh/YIBRQ2Mn1ChKE5T0ejSyLjaTGHFg6sIpCWxVZzUvPKZKTDDdtk12vovGcRWBTfY62LpJpjlcI1YMEwcCL5A7fgIwwX9pxQO/AVJUDA9cowbBpDIjJlo9ZdcdBWfLcKfgPoWtEO5UDpvZZti0rSTiRLY3a0/l8xPLpuQXq9EjUrac0srunEK6te4XQ9MuhEQRYRkTIMF4Hvqxz9HYtkByuvpiSqNfXKCGXGxYhfAFVvRUhmk2RagISwj4qzbUA==;" "mcc-time" "1532825948"
                       :Content-Type        "application/json"
                       :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                      :mauth-version       "v2"
-                      }
+                      :mauth-version       "v2"}
    :url              "https://www.mdsol.com/api/v2/testing1?testABCD=1234"
    :method           :get
    :body             "\"\""
@@ -155,12 +151,11 @@
    :as               :auto})
 
 (def mock-delete-v2
-  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:rQR2OK8w3ixCyVqMZCxzUcEObaigSLfoHSgiGbONc0MD7GrhZ3rLLefV3nUaf3g/0hQi3Irx07NU+yBNS37Orya8eufqwsod1P2FeutNbHVLFhjTG+D/+StknEemQfzV7ZZ3abejzc02QP2QWn9jUk9sQjhByPcVbxapwnM2JAj5hCKmm1hE5UsJBk6YW59gWpTUPGGkDlp39LZfTV0lDOc402STy5h56FZSd9I92LA78f6ojF2izYlmp6Q+12FjuWARn9bjBPewRk8cKhYUs3fVl4ZEFwMyQM759waX9VASE9e/UCiFZTbZL2tCrvIRFys5FYmTy53A1pYZGjJ7Kw==;"
+  {:headers          {"mcc-authentication" "MWSV2 abcd7d78-c874-47d9-a829-ccaa51ae75c9:f2qLS57HqU7ZoJx5hlhIt9nyjbB/tqiOwcWe3Y5lO7OLL2OKuR3Et8nF5SNEu4ToWrr67nu/16ztdNRC0138uRVVEdIhnPgD3z9WZZehHaoP64BHBEcleP6MBFVJ2p/9nJvqjvZ64qAkovzQf6lGQdBSp93X8MrDN/BMSxSGOUUXffPst4nzzl09dhgCCnk0vqHG8/wDELi2I5ieCxt3WVMDj+rcffm+C0e6Oc7qT4WVXYwxnVOSOZRWo7cpd5dEXTfG0KSJK47Zdoy/qlrhSY4byk+qwky57lROMixNxdeE5PNTh6qmvvvZWRVpb+vKJraP849eacgPEyBIvAezwA==;"
                       "mcc-time"           "1532825948"
                       :Content-Type        "application/json"
                       :Authorization       "da2-3ubdc4ekk5dw5n2dvwjumet3fq"
-                      :mauth-version       "v2"
-                      }
+                      :mauth-version       "v2"}
    :url              "https://www.mdsol.com/api/v2/testing1"
    :method           :delete
    :body             "\"\""
@@ -175,58 +170,49 @@
                       json/write-str))
 
 (deftest header-test
+  (get-credentials)
   (testing "It should make a valid GET request."
-    (let [creds (get-credentials)
-          get-response (get! "https://www.mdsol.com" "/api/v2/testing")]
+    (let [get-response (get! "https://www.mdsol.com" "/api/v2/testing")]
       (is (= mock-get get-response))))
 
   (testing "It should make a valid GET request with a querystring."
-    (let [creds (get-credentials)
-          get-response (get! "https://www.mdsol.com" "/api/v2/testing?testABCD=1234")]
+    (let [get-response (get! "https://www.mdsol.com" "/api/v2/testing?testABCD=1234")]
       (is (= mock-get-with-qs get-response))))
 
   (testing "It should make a valid POST request."
-    (let [creds (get-credentials)
-          post-response (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload)]
+    (let [post-response (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload)]
       (is (= mock-post post-response))))
 
   (testing "It should make a valid DELETE request."
-    (let [creds (get-credentials)
-          delete-response (delete! "https://www.mdsol.com" "/api/v2/testing2")]
+    (let [delete-response (delete! "https://www.mdsol.com" "/api/v2/testing2")]
       (is (= mock-delete delete-response))))
 
   (testing "It should make a valid PUT request."
-    (let [creds (get-credentials)
-          put-response (put! "https://www.mdsol.com" "/api/v2/testing3" mock-payload)]
+    (let [put-response (put! "https://www.mdsol.com" "/api/v2/testing3" mock-payload)]
       (is (= mock-put put-response))))
 
   (testing "It should make a valid POST request with v2 mauth header"
-    (let [creds (get-credentials)
-          post-response (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
+    (let [post-response (post! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
                                :with-sni? false)]
       (is (= mock-post-v2 post-response))))
 
   (testing "It should make a valid PUT request with v2 mauth header"
-    (let [creds (get-credentials)
-          put-response (put! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
+    (let [put-response (put! "https://www.mdsol.com" "/api/v2/testing1" mock-payload :additional-headers additional-headers
                              :with-sni? false)]
       (is (= mock-put-v2 put-response))))
 
   (testing "It should make a valid GET request with v2 mauth header"
-    (let [creds (get-credentials)
-          get-response (get! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
+    (let [get-response (get! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
                              :with-sni? false)]
       (is (= mock-get-v2 get-response))))
 
   (testing "It should make a valid GET request with query string and with v2 mauth header"
 
-    (let [creds (get-credentials)
-          get-response (get! "https://www.mdsol.com" "/api/v2/testing1?testABCD=1234" :additional-headers additional-headers
+    (let [get-response (get! "https://www.mdsol.com" "/api/v2/testing1?testABCD=1234" :additional-headers additional-headers
                              :with-sni? false)]
       (is (= mock-get-with-qs-v2 get-response))))
 
   (testing "It should make a valid DELETE request with v2 mauth header"
-    (let [creds (get-credentials)
-          delete-response (delete! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
+    (let [delete-response (delete! "https://www.mdsol.com" "/api/v2/testing1" :additional-headers additional-headers
                                    :with-sni? false)]
-      (is (= mock-delete-v2) delete-response))))
+      (is (= mock-delete-v2 delete-response)))))


### PR DESCRIPTION
The validation functionality was not including the query-string in the authentication ticket, causing that any request with query-params was unauthorized.

This PR includes the query-string in the authentication ticket for headers implementing the mauth V2 protocol.